### PR TITLE
feat(good pratices) : Fix the operator-sdk version/branch to be used as v0.5.0

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -59,8 +59,8 @@ required = [
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  branch = "master" #osdk_branch_annotation
-  # version = "=v0.5.0" #osdk_version_annotation
+  # branch = "master" #osdk_branch_annotation
+  version = "=v0.5.0" #osdk_version_annotation
 
 [prune]
   go-tests = true


### PR DESCRIPTION
## What
Fix the operator-sdk version as v0.5.0 (Suggestion made from @odra )

```
[[constraint]]
  name = "github.com/operator-framework/operator-sdk"
  # The version rule is used for a specific release and the master branch for in between releases.
  # branch = "master" #osdk_branch_annotation
  version = "=v0.5.0" #osdk_version_annotation
```

## Why
Shows that it is a good practice adopted to work with operator-sdk in order to avoid issues and or breakchanges that may occur because of the updates made in the master branch. 
