### PR TITLE
feat(automatization) : Create makefile (AEROGEAR-8863)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+APP_NAME = mobile-security-service-operator
+ORG_NAME = aerogear
+PKG = github.com/$(ORG_NAME)/$(APP_NAME)
+APP_FILE=./cmd/manager/main.go
+BIN_DIR := $(GOPATH)/bin
+BINARY ?= mobile-security-service-operator
+TAG= 0.1.0
+DOCKER-ORG=cmacedo
+DOCKER-REPO=mobile-security-service-operator
+
+# This follows the output format for goreleaser
+BINARY_LINUX_64 = ./dist/linux_amd64/$(BINARY)
+
+LDFLAGS=-ldflags "-w -s -X main.Version=${TAG}"
+
+.PHONY: deploy
+deploy:
+	@echo Deploying Mobile Security Service Operator:
+	oc create namespace mobile-security-service
+	oc create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
+	oc create -f deploy/cluster_role.yaml
+	oc create -f deploy/cluster_role_binding.yaml
+	oc create -f deploy/service_account.yaml
+	oc create -f deploy/operator.yaml
+
+.PHONY: undeploy
+undeploy:
+	@echo Undeploy Mobile Security Service Operator:
+	oc delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
+	oc delete -f deploy/cluster_role.yaml
+	oc delete -f deploy/cluster_role_binding.yaml
+	oc delete -f deploy/service_account.yaml
+	oc delete -f deploy/operator.yaml
+	oc delete namespace mobile-security-service
+
+.PHONY: deploy-app
+deploy-app:
+	@echo Deploying Mobile Security Service into project:
+	oc apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+
+.PHONY: undeploy-app
+undeploy-app:
+	@echo Undeploying Mobile Security Service from the project:
+	oc delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+
+.PHONY: build
+build:
+	@echo Buinding operator with the tag $(TAG):
+	operator-sdk build cmacedo/mobile-security-service-operator:$(TAG)
+
+.PHONY: publish
+publish:
+	@echo Publishing operator in $(DOCKER-ORG)/$(DOCKER-REPO) with the tag $(TAG):
+	docker push $(DOCKER-ORG)/$(DOCKER-REPO):$(TAG)

--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,6 @@ NOTE: This project is a POC
 |https://github.com/golang/go/wiki/SettingGOPATH[Ensure the $GOPATH environment variable is set]
 |https://golang.github.io/dep/docs/installation.html[Install the dep package manager]
 |https://github.com/operator-framework/operator-sdk#quick-start[Install Operator-SDK]
-|https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl[Install kubectl]
 |===
 
 == Getting Started
@@ -71,27 +70,42 @@ NOTE: This operator will be installed in the cluster level.
 
 ==== To deploy Mobile Security Service Operator
 
-Run the following commands to deploy the operator in your cluster.
+Use the following command.
 
 [source,shell]
 ----
-$ kubectl create namespace mobile-security-service
-$ kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
-$ kubectl create -f deploy/cluster_role.yaml
-$ kubectl create -f deploy/cluster_role_binding.yaml
-$ kubectl create -f deploy/service_account.yaml
-$ kubectl create -f deploy/operator.yaml
+$ make deploy
 ----
 
-NOTE: You can use `oc` tools instead of `kubectl`. E.g. (`$ oc create namespace mobile-security-service`)
+NOTE: Following commands which will be executed with the `make deploy` to deploy the operator in your cluster.
+
+[source,shell]
+----
+$ oc create namespace mobile-security-service
+$ oc create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
+$ oc create -f deploy/cluster_role.yaml
+$ oc create -f deploy/cluster_role_binding.yaml
+$ oc create -f deploy/service_account.yaml
+$ oc create -f deploy/operator.yaml
+----
+
+TIP: You can use `kubectl` tool instead of `oc`. E.g. (`$ kubectl create namespace mobile-security-service`)
 
 === To deploy Mobile Security Service in a Project(Namespace)
-To deploy the project run the following command inside of the project where you would like to have the https://github.com/aerogear/mobile-security-service[Mobile Security Service] installed and running.
+
+Use the following command.
 
 [source,shell]
 ----
 $ oc project <my-project>
-$ kubectl apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+$ make deploy-app
+----
+
+NOTE: Following the command which will be executed with the `make deploy-app` to deploy the Mobile Security Service in your project.
+
+[source,shell]
+----
+$ oc apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
 ----
 
 === To remove Mobile Security Service from the Project(Namespace)
@@ -101,21 +115,35 @@ The following command will remove all configuration made by the operator in the 
 [source,shell]
 ----
 $ oc project <my-project>
-$ kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+$ make undeploy-app
 ----
 
-=== To remove Mobile Security Service Operator from your cluster.
-
-The following commands will clean your cluster and remove all objects created for this operator.
+NOTE: Following the command which will be executed with the `make undeploy-app` to undeploy the Mobile Security Service from your project.
 
 [source,shell]
 ----
-$ kubectl delete namespace mobile-security-service
-$ kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
-$ kubectl delete -f deploy/cluster_role.yaml
-$ kubectl delete -f deploy/cluster_role_binding.yaml
-$ kubectl delete -f deploy/service_account.yaml
-$ kubectl delete -f deploy/operator.yaml
+$ oc delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+----
+
+=== To remove Mobile Security Service Operator from your cluster
+
+Use the following command.
+
+[source,shell]
+----
+$ make undeploy
+----
+
+NOTE: Following commands which will be executed with the `make undeploy` to undeploy the operator from your cluster.
+
+[source,shell]
+----
+$ oc delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
+$ oc delete -f deploy/cluster_role.yaml
+$ oc delete -f deploy/cluster_role_binding.yaml
+$ oc delete -f deploy/service_account.yaml
+$ oc delete -f deploy/operator.yaml
+$ oc delete namespace mobile-security-service
 ----
 
 == Mobile Security Service Configurations
@@ -132,6 +160,20 @@ oc create \
   --role=mobile-security-service-operator \
   --user=developer
 ----
+
+== Using make commands
+
+|===
+| *Command*                     | *Description*
+| `make deploy`                 | Create mobile-security-service namespace and deploy operator and roles`
+| `make undeploy`               | Remove mobile-security-service namespace and undeploy operator and roles`
+| `make deploy-app`             | Deploy Mobile Security Service in the project`
+| `make undeploy-app`           | Undeploy Mobile Security Service in the project`
+| `make build`                  | Build operator for development proposes`
+| `make publish`                | Publish operator in https://hub.docker.com/[Docker Hub]`
+|===
+
+NOTE: The link:./Makefile[Makefile] is implemented with tasks which you should use to work with.
 
 == Contributing
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: mobile-security-service-operator
           # Replace this with the built image name
-          image: cmacedo/mobile-security-service-operator:v0.4.0
+          image: cmacedo/mobile-security-service-operator:0.1.0
           command:
           - mobile-security-service-operator
           imagePullPolicy: Always

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.4.0"
+	Version = "0.1.0"
 )


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8863

## What
* Create Makefile with commands for the operator
* Update Readme with
* Remove Kubernetes tool from pre-requirement and replace it for OC tool

## Why
* Make easer the test and use it
* Following the best practices

## Verification Steps
1. Run the commands described in the README 

```
| *Command*                     | *Description*
| `make deploy`                 | Create mobile-security-service namespace and deploy operator and roles`
| `make undeploy`               | Remove mobile-security-service namespace and undeploy operator and roles`
| `make deploy-app`             | Deploy Mobile Security Service in the project`
| `make undeploy-app`           | Undeploy Mobile Security Service in the project`
| `make build`                  | Build operator for development proposes`
| `make publish`                | Publish operator in https://hub.docker.com/[Docker Hub]`
```

2. Check that all worked well as expected

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
Following the local test performed.  

```
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (makefile) $ make build
Buinding operator with the tag 0.1.0:
operator-sdk build cmacedo/mobile-security-service-operator:0.1.0
INFO[0001] Building Docker image cmacedo/mobile-security-service-operator:0.1.0 
Sending build context to Docker daemon  227.2MB
Step 1/7 : FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:7.6
 ---> 1f8526ca508d
Step 2/7 : ENV OPERATOR=/usr/local/bin/mobile-security-service-operator     USER_UID=1001     USER_NAME=mobile-security-service-operator
 ---> Using cache
 ---> e37d7a7f8754
Step 3/7 : COPY build/_output/bin/mobile-security-service-operator ${OPERATOR}
 ---> Using cache
 ---> e794953c1b72
Step 4/7 : COPY build/bin /usr/local/bin
 ---> Using cache
 ---> 178168efdfa3
Step 5/7 : RUN  /usr/local/bin/user_setup
 ---> Using cache
 ---> 281daea1a795
Step 6/7 : ENTRYPOINT ["/usr/local/bin/entrypoint"]
 ---> Using cache
 ---> 19ea5d329f6b
Step 7/7 : USER ${USER_UID}
 ---> Using cache
 ---> f394bf42f549
Successfully built f394bf42f549
Successfully tagged cmacedo/mobile-security-service-operator:0.1.0
INFO[0005] Operator build complete.                     
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (makefile) $ make publish
Publishing operator in cmacedo/mobile-security-service-operator with the tag 0.1.0:
docker push cmacedo/mobile-security-service-operator:0.1.0
The push refers to repository [docker.io/cmacedo/mobile-security-service-operator]
35e9432edecd: Layer already exists 
76f538482802: Layer already exists 
498afb8c338c: Layer already exists 
48eeec1f62af: Layer already exists 
5bfa1c2bc41d: Layer already exists 
0.1.0: digest: sha256:81df50486fc5b0cee98b7c32fc55b94ec8cdc653d18c50ec238895071c9e20a0 size: 1363
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (makefile) $ make undeploy
Undeploy Mobile Security Service Operator:
oc delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
customresourcedefinition.apiextensions.k8s.io "mobilesecurityservices.mobile-security-service.aerogear.com" deleted
oc delete -f deploy/cluster_role.yaml
clusterrole.rbac.authorization.k8s.io "mobile-security-service-operator" deleted
oc delete -f deploy/cluster_role_binding.yaml
clusterrolebinding.rbac.authorization.k8s.io "mobile-security-service-operator" deleted
oc delete -f deploy/service_account.yaml
serviceaccount "mobile-security-service-operator" deleted
oc delete -f deploy/operator.yaml
deployment.apps "mobile-security-service-operator" deleted
oc delete namespace mobile-security-service
namespace "mobile-security-service" deleted
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (makefile) $ make deploy
Deploying Mobile Security Service Operator:
oc create namespace mobile-security-service
namespace/mobile-security-service created
oc create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
customresourcedefinition.apiextensions.k8s.io/mobilesecurityservices.mobile-security-service.aerogear.com created
oc create -f deploy/cluster_role.yaml
clusterrole.rbac.authorization.k8s.io/mobile-security-service-operator created
oc create -f deploy/cluster_role_binding.yaml
clusterrolebinding.rbac.authorization.k8s.io/mobile-security-service-operator created
oc create -f deploy/service_account.yaml
serviceaccount/mobile-security-service-operator created
oc create -f deploy/operator.yaml
deployment.apps/mobile-security-service-operator created
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (makefile) $ make deploy-app
Deploying Mobile Security Service into project:
oc apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
mobilesecurityservice.mobile-security-service.aerogear.com/mobile-security-service-app created
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (makefile) $ make undeploy-app
Undeploying Mobile Security Service from the project:
oc delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
mobilesecurityservice.mobile-security-service.aerogear.com "mobile-security-service-app" deleted

```