### PR TITLE
feat(role) : Add role to allow users create the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ deploy:
 	kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
 	kubectl create -f deploy/cluster_role.yaml
 	kubectl create -f deploy/cluster_role_binding.yaml
+	kubectl create -f deploy/role.yaml
+	kubectl create -f deploy/role_binding.yaml
 	kubectl create -f deploy/service_account.yaml
 	kubectl create -f deploy/operator.yaml
 
@@ -33,6 +35,8 @@ undeploy:
 	kubectl delete -f deploy/cluster_role_binding.yaml
 	kubectl delete -f deploy/service_account.yaml
 	kubectl delete -f deploy/operator.yaml
+	kubectl delete -f deploy/role.yaml
+	kubectl delete -f deploy/role_binding.yaml
 	kubectl delete namespace mobile-security-service-operator
 
 .PHONY: deploy-app

--- a/README.adoc
+++ b/README.adoc
@@ -218,11 +218,21 @@ $ make build
 $ make publish
 ----
 
-== Mobile Security Service Configurations
+== Mobile Security Service Application and Database configurations
 
 The environment variables used in this project are configured by the Config Map which is created by the operator. To have a further understatement over its configuration see https://github.com/aerogear/mobile-security-service#setup-and-configurations[Setup and Configurations] section of https://github.com/aerogear/mobile-security-service[Mobile Security Service].
 
 TIP: For example, see that the name of the database is mapped in the ConfigMap which is used by Mobile Security Service application and database. Note that to connect to the database with the default values you may use the command: `psql -h localhost -U postgresql mobile_security_service.
+
+== Creating Role for no-privilege users are able to create the application and database in their namespaces
+
+By executing the following commands you will create roles in the cluster which will allow the <user> create the Mobile Security Service Application and Database in their namespaces. However, the Mobile Security Service Operator is cluster scoped and will still only accessible for the system admin users. (E.g `oc login -u system:admin`)
+
+[source,shell]
+----
+$ oc create rolebinding developer-mobile-security-service-operator --role=mobile-security-service-operator --user=<user>
+$ oc create rolebinding developer-mobile-security-service --role=mobile-security-service --user=developer
+----
 
 == Using make commands
 
@@ -241,13 +251,13 @@ TIP: For example, see that the name of the database is mapped in the ConfigMap w
 
 NOTE: The link:./Makefile[Makefile] is implemented with tasks which you should use to work with.
 
-== Contributing
-
-All contributions are hugely appreciated. Please see our https://aerogear.org/community/#guides[Contributing Guide] for guidelines on how to open issues and pull requests. Please check out our link:./.github/CODE_OF_CONDUCT.md[Code of Conduct] too.
-
 == Supportability
 
 This operator was developed using the k8s APIs and should work well in Kubernetes and OpenShift clusters.
+
+== Contributing
+
+All contributions are hugely appreciated. Please see our https://aerogear.org/community/#guides[Contributing Guide] for guidelines on how to open issues and pull requests. Please check out our link:./.github/CODE_OF_CONDUCT.md[Code of Conduct] too.
 
 == Questions
 

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,0 +1,48 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mobile-security-service
+rules:
+- apiGroups:
+  - "mobile-security-service.aerogear.com"
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - "*"
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - "get"
+  - "create"
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - mobile-security-service-app
+  - mobile-security-service-db
+  verbs:
+  - "*"

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mobile-security-service
+subjects:
+- kind: ServiceAccount
+  name: mobile-security-service
+roleRef:
+  kind: Role
+  name: mobile-security-service
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8870

## What
Allow developers to use the operator and install the Mobile Security Service when the system:admin installed it.

## Why
Users/developer should be able to use the Operator to create the Mobile Security Service App and Database in their namespaces, however, they should still not able to create the Operator. 

## How
Creating specific roles.

## Verification Steps
1. Following the steps in the README
With the system:admin user:
- Run make deploy
- Run the following roles commands

```
$ oc create   rolebinding developer-mobile-security-service-operator   --role=mobile-security-service-operator   --user=developer

$ oc create   rolebinding developer-mobile-security-service --role=mobile-security-service   --user=developer
```

2. Login with the developer user
- Create a project `oc new-project test`
- Install the Mobile Security Service App and Database by `make deploy-app`

3. Try to run `make deploy` with the developer user and check that itl will not work

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
Local Test:

```
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (AEROGEAR-8870) $ make deploy
Deploying Mobile Security Service Operator:
kubectl create namespace mobile-security-service-operator
Error from server (Forbidden): namespaces is forbidden: User "developer" cannot create namespaces at the cluster scope: no RBAC policy matched
make: *** [deploy] Error 1
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (AEROGEAR-8870) $ make undeploy
Undeploy Mobile Security Service Operator:
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
Error from server (Forbidden): error when deleting "deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml": customresourcedefinitions.apiextensions.k8s.io "mobilesecurityservices.mobile-security-service.aerogear.com" is forbidden: User "developer" cannot delete customresourcedefinitions.apiextensions.k8s.io at the cluster scope: no RBAC policy matched
make: *** [undeploy] Error 1
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (AEROGEAR-8870) $ make deploy
Deploying Mobile Security Service Operator:
kubectl create namespace mobile-security-service-operator
Error from server (Forbidden): namespaces is forbidden: User "developer" cannot create namespaces at the cluster scope: no RBAC policy matched
make: *** [deploy] Error 1
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (AEROGEAR-8870) $ make deploy-app
Deploying Mobile Security Service and Database into project:
kubectl apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
mobilesecurityservice.mobile-security-service.aerogear.com/mobile-security-service-app unchanged
kubectl apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
mobilesecurityservicedb.mobile-security-service.aerogear.com/mobile-security-service-db unchanged
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (AEROGEAR-8870) $ make undeploy-app
Undeploying Mobile Security Service and Database from the project:
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
mobilesecurityservice.mobile-security-service.aerogear.com "mobile-security-service-app" deleted
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
mobilesecurityservicedb.mobile-security-service.aerogear.com "mobile-security-service-db" deleted
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (AEROGEAR-8870) $ 

```

