### PR TITLE
fix(makefile): Undeploy commands do not stop when find errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,15 @@ deploy:
 .PHONY: undeploy
 undeploy:
 	@echo Undeploy Mobile Security Service Operator:
-	kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
-	kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
-	kubectl delete -f deploy/cluster_role.yaml
-	kubectl delete -f deploy/cluster_role_binding.yaml
-	kubectl delete -f deploy/service_account.yaml
-	kubectl delete -f deploy/operator.yaml
-	kubectl delete -f deploy/role.yaml
-	kubectl delete -f deploy/role_binding.yaml
-	kubectl delete namespace mobile-security-service-operator
+	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
+	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
+	- kubectl delete -f deploy/cluster_role.yaml
+	- kubectl delete -f deploy/cluster_role_binding.yaml
+	- kubectl delete -f deploy/service_account.yaml
+	- kubectl delete -f deploy/operator.yaml
+	- kubectl delete -f deploy/role.yaml
+	- kubectl delete -f deploy/role_binding.yaml
+	- kubectl delete namespace mobile-security-service-operator
 
 .PHONY: deploy-app
 deploy-app:
@@ -58,8 +58,8 @@ deploy-db-only:
 .PHONY: undeploy-app
 undeploy-app:
 	@echo Undeploying Mobile Security Service and Database from the project:
-	kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
-	kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
+	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
 
 .PHONY: undeploy-app-only
 undeploy-app-only:


### PR DESCRIPTION
## Motivation
Fix error found in the tests

## What
Do not stop the execution in the `make undeploy` when some error is faced 

## Why
If something goes wrong and some rule or actions is missing the command should try to clean all. 

## How
Using the `-` in front of the command

## Verification Steps
1. Call the command `make undeploy` with the operator not deployed in the cluster. All commands should be called. 

```
$ make undeploy
Undeploy Mobile Security Service Operator:
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
Error from server (NotFound): error when deleting "deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml": customresourcedefinitions.apiextensions.k8s.io "mobilesecurityservices.mobile-security-service.aerogear.com" not found
make: [undeploy] Error 1 (ignored)
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
Error from server (NotFound): error when deleting "deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml": customresourcedefinitions.apiextensions.k8s.io "mobilesecurityservicedbs.mobile-security-service.aerogear.com" not found
make: [undeploy] Error 1 (ignored)
kubectl delete -f deploy/cluster_role.yaml
Error from server (NotFound): error when deleting "deploy/cluster_role.yaml": clusterroles.rbac.authorization.k8s.io "mobile-security-service-operator" not found
make: [undeploy] Error 1 (ignored)
kubectl delete -f deploy/cluster_role_binding.yaml
Error from server (NotFound): error when deleting "deploy/cluster_role_binding.yaml": clusterrolebindings.rbac.authorization.k8s.io "mobile-security-service-operator" not found
make: [undeploy] Error 1 (ignored)
kubectl delete -f deploy/service_account.yaml
Error from server (NotFound): error when deleting "deploy/service_account.yaml": serviceaccounts "mobile-security-service-operator" not found
make: [undeploy] Error 1 (ignored)
kubectl delete -f deploy/operator.yaml
Error from server (NotFound): error when deleting "deploy/operator.yaml": deployments.apps "mobile-security-service-operator" not found
make: [undeploy] Error 1 (ignored)
kubectl delete -f deploy/role.yaml
Error from server (NotFound): error when deleting "deploy/role.yaml": roles.rbac.authorization.k8s.io "mobile-security-service" not found
make: [undeploy] Error 1 (ignored)
kubectl delete -f deploy/role_binding.yaml
Error from server (NotFound): error when deleting "deploy/role_binding.yaml": rolebindings.rbac.authorization.k8s.io "mobile-security-service" not found
make: [undeploy] Error 1 (ignored)
kubectl delete namespace mobile-security-service-operator
Error from server (NotFound): namespaces "mobile-security-service-operator" not found
make: [undeploy] Error 1 (ignored)

```

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 
