### PR TITLE
feat(operator/services) : Install all in the same namespace (AEROGEAR-8963)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,18 +13,31 @@ BINARY_LINUX_64 = ./dist/linux_amd64/$(BINARY)
 
 LDFLAGS=-ldflags "-w -s -X main.Version=${TAG}"
 
+
+.PHONY: deploy-all
+deploy-all:
+	@echo Deploying Mobile Security Service Operator and Service in the namespace "mobile-security-service-operator":
+	make deploy
+	make deploy-app
+
+.PHONY: undeploy-all
+undeploy-all:
+	@echo UnDeploying Mobile Security Service Operator and Service and removing the namespace "mobile-security-service-operator":
+	make undeploy
+	make undeploy-app
+
 .PHONY: deploy
 deploy:
 	@echo Deploying Mobile Security Service Operator:
-	kubectl create namespace mobile-security-service-operator
-	kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
-	kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
-	kubectl create -f deploy/cluster_role.yaml
-	kubectl create -f deploy/cluster_role_binding.yaml
-	kubectl create -f deploy/role.yaml
-	kubectl create -f deploy/role_binding.yaml
-	kubectl create -f deploy/service_account.yaml
-	kubectl create -f deploy/operator.yaml
+	- kubectl create namespace mobile-security-service-operator
+	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
+	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
+	- kubectl create -f deploy/cluster_role.yaml
+	- kubectl create -f deploy/cluster_role_binding.yaml
+	- kubectl create -f deploy/role.yaml
+	- kubectl create -f deploy/role_binding.yaml
+	- kubectl create -f deploy/service_account.yaml
+	- kubectl create -f deploy/operator.yaml
 
 .PHONY: undeploy
 undeploy:

--- a/README.adoc
+++ b/README.adoc
@@ -66,6 +66,28 @@ $ minishift addon enable admin-user
 $ minishift start
 ----
 
+=== To install the Operator and Service
+
+Use the following command.
+
+[source,shell]
+----
+$ make deploy-all
+----
+
+IMPORTANT: To install the Operator and Service you need be logged as admin since they will be in the cluster level.
+
+=== To uninstall the Operator and Service
+
+Use the following command.
+
+[source,shell]
+----
+$ make undeploy-all
+----
+
+== More options to install
+
 === To install Mobile Security Service Operator in cluster
 
 ==== Login as system:admin
@@ -91,7 +113,7 @@ Update the "mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml" with
   hostSufix: ".nip.io"
 ----
 
-==== To deploy Mobile Security Service Operator
+==== To deploy ONLY Mobile Security Service Operator
 
 Use the following command.
 
@@ -115,13 +137,12 @@ $ kubectl create -f deploy/operator.yaml
 
 TIP: You can use `oc` tool instead of `kubectl`. E.g. (`$ oc create namespace mobile-security-service`)
 
-=== To deploy Mobile Security Service in a Project(Namespace) with its database
+=== To deploy ONLY Mobile Security Service with its database
 
 Use the following command.
 
 [source,shell]
 ----
-$ oc project <my-project>
 $ make deploy-app
 ----
 
@@ -133,13 +154,12 @@ $ kubectl apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityse
 $ kubectl apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
 ----
 
-=== To remove Mobile Security Service from the Project(Namespace) and its database
+=== To remove ONLY Mobile Security Service from and its database
 
-The following command will remove all configuration made by the operator in the project/namespace.
+Use the following command.
 
 [source,shell]
 ----
-$ oc project <my-project>
 $ make undeploy-app
 ----
 
@@ -151,7 +171,7 @@ $ kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecuritys
 $ kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
 ----
 
-=== To remove Mobile Security Service Operator from your cluster
+=== To remove ONLY Mobile Security Service Operator from your cluster
 
 Use the following command.
 
@@ -173,23 +193,43 @@ $ kubectl delete -f deploy/operator.yaml
 $ kubectl delete namespace mobile-security-service-operator
 ----
 
-=== To deploy Mobile Security Service project without the database
+=== To deploy Mobile Security Service App without the database
 
 Note that this operator has one type for the project and another for its database. In this way, its possible deploy them separately.
 
-Use the following command to deploy just the Mobile Security Service in your project
+Use the following command to deploy only the Mobile Security Service App.
 
 [source,shell]
 ----
 $ make deploy-app-only
 ----
 
-NOTE: Following the command which will be executed with the `make deploy-app-only` to deploy the Mobile Security Service into your project.
+NOTE: Following the command which will be executed with the `make deploy-app-only` to deploy the Mobile Security Service App.
 
 [source,shell]
 ----
 $ oc create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
 ----
+
+NOTE: Also, you can use `make undeploy-app-only`
+
+=== To deploy ONLY Mobile Security Service Database
+
+Use the following command to deploy only the Mobile Security Service Database.
+
+[source,shell]
+----
+$ make deploy-db-only
+----
+
+NOTE: Following the command which will be executed with the `make deploy-db-only` to deploy the Mobile Security Service DB.
+
+[source,shell]
+----
+$ oc create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
+----
+
+NOTE: Also, you can use `make undeploy-db-only`
 
 == To publish an new version of this operator
 
@@ -248,6 +288,9 @@ $ oc create rolebinding developer-mobile-security-service --role=mobile-security
 
 |===
 | *Command*                     | *Description*
+| `make deploy-all`             | Create mobile-security-service-operator namespace and deploy operator, roles and Service`
+| `make undeploy-all`           | Delete mobile-security-service-operator namespace and undeploy operator, roles and Service`
+| `make undeploy`               | Remove mobile-security-service namespace and undeploy operator and roles`
 | `make deploy`                 | Create mobile-security-service namespace and deploy operator and roles`
 | `make undeploy`               | Remove mobile-security-service namespace and undeploy operator and roles`
 | `make deploy-app`             | Deploy Mobile Security Service and its database in the project`

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
@@ -2,6 +2,7 @@ apiVersion: mobile-security-service.aerogear.com/v1alpha1
 kind: MobileSecurityService
 metadata:
   name: mobile-security-service-app
+  namespace: mobile-security-service-operator
 spec:
   size: 1
   # It is the image:tag used to create the mobile security service deployment

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mobilesecurityservices.mobile-security-service.aerogear.com
+  namespace: mobile-security-service-operator
 spec:
   group: mobile-security-service.aerogear.com
   names:

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
@@ -2,6 +2,7 @@ apiVersion: mobile-security-service.aerogear.com/v1alpha1
 kind: MobileSecurityServiceDB
 metadata:
   name: mobile-security-service-db
+  namespace: mobile-security-service-operator
 spec:
   size: 1
   image: "postgres:9.6"

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: mobilesecurityservicedbs.mobile-security-service.aerogear.com
+  namespace: mobile-security-service-operator
 spec:
   group: mobile-security-service.aerogear.com
   names:


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8963

## What
Change the operator - The App and DB should be created in the same namespace of the operator

## Why
- All will be installed in the admin view
- Just one MSS will be available by cluster

## How
- Adding the fixed namespace to the CR
- By Creating new commands
- By updating the README

## Verification Steps
1. Run the command `make deploy-all`
2. Check that all will be installed in the same namespace as the following image.
<img width="1483" alt="Screenshot 2019-04-03 at 12 04 46" src="https://user-images.githubusercontent.com/7708031/55474594-79393f00-5609-11e9-9bd6-3216e0d6230b.png">

3. Run the command `make undeploy-all`
4. Check that all recourses, roles and the namespace were removed. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
