### PR TITLE
feat(MSS) : Use/Install the latest version of MSS by the Operator always

### DIFF
--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   size: 1
   # It is the image:tag used to create the mobile security service deployment
-  image: "aerogear/mobile-security-service:master"
+  image: "aerogear/mobile-security-service:latest"
   containerName: "application"
   # The following values will be used to create the ConfigMap with the Environment Variables
   # which will be used by thee Mobile Security Service App and Database

--- a/pkg/controller/mobilesecurityservice/deployments.go
+++ b/pkg/controller/mobilesecurityservice/deployments.go
@@ -42,7 +42,7 @@ func (r *ReconcileMobileSecurityService) buildAppDeployment(m *mobilesecurityser
 					Containers: []corev1.Container{{
 						Image:           m.Spec.Image,
 						Name:            m.Spec.ContainerName,
-						ImagePullPolicy: corev1.PullIfNotPresent,
+						ImagePullPolicy: corev1.PullAlways,
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: m.Spec.Port,
 							Name:          "http",


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8985

## What
Use/Install the latest version of MSS by the Operator always

## Why
Operator should be capable of updating the MSS to a new version, when a new version of MSS is released.

 ## How
- Using the ImagePullPolicy: corev1.PullAlways,
- Getting the images based in the master branch: "aerogear/mobile-security-service:lastest"

## Verification Steps
1. Run the command `make deploy-all`
2. Check that all will be installed in the same namespace as the following image.
<img width="1483" alt="Screenshot 2019-04-03 at 12 04 46" src="https://user-images.githubusercontent.com/7708031/55474594-79393f00-5609-11e9-9bd6-3216e0d6230b.png">

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
* kubernetes implementation regards the image policy: https://github.com/kubernetes/api/blob/master/core/v1/types.go#L2031
* Currently, for Mobile Security Service the latest version is always published when some change is merged in the master.

<img width="1267" alt="Screenshot 2019-04-03 at 12 47 54" src="https://user-images.githubusercontent.com/7708031/55476597-ec917f80-560e-11e9-84ef-c4d6445899c0.png">
 
