### PR TITLE
feat(dev) : Add dev tag to allow build and publish tag for dev purpose only (AEROGEAR-8994)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ APP_FILE=./cmd/manager/main.go
 BIN_DIR := $(GOPATH)/bin
 BINARY ?= mobile-security-service-operator
 TAG= 0.1.0
+DEV= dev
 DOCKER-ORG=aerogear
 DOCKER-REPO=mobile-security-service-operator
 
@@ -93,6 +94,18 @@ build:
 publish:
 	@echo Publishing operator in $(DOCKER-ORG)/$(DOCKER-REPO) with the tag $(TAG):
 	docker push $(DOCKER-ORG)/$(DOCKER-REPO):$(TAG)
+
+
+.PHONY: build-dev
+build-dev:
+	@echo Buinding operator with the tag $(TAG)$(DEV):
+	operator-sdk build $(DOCKER-ORG)/$(DOCKER-REPO):$(TAG)-$(DEV)
+
+
+.PHONY: publish-dev
+publish-dev:
+	@echo Publishing operator in $(DOCKER-ORG)/$(DOCKER-REPO) with the tag $(TAG)-$(DEV):
+	docker push $(DOCKER-ORG)/$(DOCKER-REPO):$(TAG)-$(DEV)
 
 .PHONY: vet
 vet:

--- a/README.adoc
+++ b/README.adoc
@@ -284,6 +284,26 @@ $ oc create rolebinding developer-mobile-security-service-operator --role=mobile
 $ oc create rolebinding developer-mobile-security-service --role=mobile-security-service --user=developer
 ----
 
+== Local development
+
+=== To build and publish a development tag
+
+[source,shell]
+----
+$ make build-dev
+$ make publish-dev
+----
+
+=== To use locally the development tag
+
+Update the image tag in the file `/mobile-security-service-operator/deploy/operator.yaml` with the development tag as follows.
+
+[source,yaml]
+----
+# Replace this with the built image name
+image: aerogear/mobile-security-service-operator:0.1.0-dev
+----
+
 == Using make commands
 
 |===
@@ -296,8 +316,10 @@ $ oc create rolebinding developer-mobile-security-service --role=mobile-security
 | `make deploy-app`             | Deploy Mobile Security Service and its database in the project`
 | `make deploy-app-only`        | Deploy Mobile Security Service without its database in the project`
 | `make undeploy-app`           | Undeploy Mobile Security Service e and its database in from the project`
-| `make build`                  | Build operator for development proposes`
+| `make build`                  | Build operator`
 | `make publish`                | Publish operator in https://hub.docker.com/[Docker Hub]`
+| `make build-dev`              | Build operator for development proposes`
+| `make publish-dev`            | Publish operator in https://hub.docker.com/[Docker Hub] for development proposes`
 | `make vet`                    | Examines source code and reports suspicious constructs using https://golang.org/cmd/vet/[vet]
 | `make fmt`                    | Formats code using https://golang.org/cmd/gofmt/[gofmt]
 |===


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8994

## What
- Add dev tag to allow build and publish tag for dev purpose only
- Add make command for dev build and publish
- Update Readme with the info

## Why
The dev changes do not impact the "prod" tag image

## Verification Steps
1. Run `make build-dev` and `publish-dev``
2. Ensure that the tag was built and published
3. Test it working by doing a full deploy (`make deploy-all`) 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<img width="846" alt="Screenshot 2019-04-03 at 15 35 30" src="https://user-images.githubusercontent.com/7708031/55487507-228e2e00-5626-11e9-8f5d-d70cc2d1966e.png">
 
