### PR TITLE
feat(Bind) : Add controller (AEROGEAR-8971)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,16 @@ LDFLAGS=-ldflags "-w -s -X main.Version=${TAG}"
 .PHONY: create-all
 create-all:
 	@echo Create Mobile Security Service Operator and Service in the namespace "mobile-security-service-operator":
-	make create
+	make create-oper
 	make create-app
+	make create-bind
 
 .PHONY: delete-all
 delete-all:
 	@echo Delete Mobile Security Service Operator, Service and namespace "mobile-security-service-operator":
-	make delete
+	make delete-oper
 	make delete-app
+	make delete-bind
 
 .PHONY: create-oper
 create-oper:
@@ -33,27 +35,37 @@ create-oper:
 	- kubectl create namespace mobile-security-service-operator
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
+	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_crd.yaml
 	- kubectl create -f deploy/cluster_role.yaml
 	- kubectl create -f deploy/cluster_role_binding.yaml
 	- kubectl create -f deploy/role.yaml
 	- kubectl create -f deploy/role_binding.yaml
 	- kubectl create -f deploy/service_account.yaml
 	- kubectl create -f deploy/operator.yaml
-	- make apply-bind-crd
 
 .PHONY: delete-oper
 delete-oper:
 	@echo Deleting Mobile Security Service Operator and namespace:
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
+	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_crd.yaml
 	- kubectl delete -f deploy/cluster_role.yaml
 	- kubectl delete -f deploy/cluster_role_binding.yaml
 	- kubectl delete -f deploy/service_account.yaml
 	- kubectl delete -f deploy/operator.yaml
 	- kubectl delete -f deploy/role.yaml
 	- kubectl delete -f deploy/role_binding.yaml
-	- make delete-bind-crd
 	- kubectl delete namespace mobile-security-service-operator
+
+.PHONY: create-bind
+create-bind:
+	@echo Creating Mobile Security Service Bind:
+	kubectl apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
+
+.PHONY: delete-bind
+delete-bind:
+	@echo Deleting Mobile Security Service Bind:
+	kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
 
 .PHONY: create-app
 create-app:
@@ -61,15 +73,6 @@ create-app:
 	kubectl apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
 	kubectl apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
 
-.PHONY: apply-bind-crd
-apply-bind-crd:
-	@echo Applying Mobile Security Service Bind CRD:
-	kubectl apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_crd.yaml
-
-.PHONY: delete-bind-crd
-delete-bind-crd:
-	@echo Deleting Mobile Security Service Bind CRD:
-	kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_crd.yaml
 
 .PHONY: create-app-only
 create-app-only:

--- a/README.adoc
+++ b/README.adoc
@@ -91,7 +91,7 @@ Update the "mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml" with
   hostSufix: ".nip.io"
 ----
 
-=== Creating Operator, Service and Roles in the cluster
+=== Creating Operator, Service and Roles
 
 Use the following command.
 
@@ -102,7 +102,8 @@ $ make create-all
 
 IMPORTANT: To apply you need be logged as admin. (`oc login -u system:admin`)
 
-=== Deleting the Operator, Service and roles from hee cluster
+
+=== Deleting the Operator, Service and Roles
 
 Use the following command.
 
@@ -113,7 +114,7 @@ $ make delete-all
 
 IMPORTANT: To delete you need be logged as admin. (`oc login -u system:admin`)
 
-== More options to install
+== More specific options to install
 
 === To create ONLY Mobile Security Service Operator
 
@@ -233,6 +234,17 @@ $ oc create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservic
 
 NOTE: Also, you can use `make delete-db-only`
 
+=== To Only Create the Bind
+
+By the following command will be possible to create the Bind which watches the applications and perform the required actions when the Mobile Security Service is binding, unbinding and/or rebinding to them.
+
+[source,shell]
+----
+$ make create-bind
+----
+
+NOTE: Also, you can use `make delete-bind`
+
 == Mobile Security Service Application and Database configurations
 
 The environment variables used in this project are configured by the Config Map which is created by the operator. To have a further understatement over its configuration see https://github.com/aerogear/mobile-security-service#setup-and-configurations[Setup and Configurations] section of https://github.com/aerogear/mobile-security-service[Mobile Security Service].
@@ -246,7 +258,7 @@ By executing the following commands you will create roles in the cluster which w
 [source,shell]
 ----
 $ oc create rolebinding developer-mobile-security-service-operator --role=mobile-security-service-operator --user=<user>
-$ oc create rolebinding developer-mobile-security-service --role=mobile-security-service --user=developer
+$ oc create rolebinding developer-mobile-security-service --role=mobile-security-service --user=<user>
 ----
 
 == Local development
@@ -322,8 +334,8 @@ image: aerogear/mobile-security-service-operator:0.1.0-dev
 | `make delete-app-only`        | Delete Mobile Security Service App only`
 | `make create-db-only`         | Create Mobile Security Service Database without its application`
 | `make delete-db-only`         | Delete Mobile Security Service Database only`
-| `make apply-bind-crd`         | Apply Mobile Security Service Bind CRD`
-| `make delete-bind-crd`        | Delete Mobile Security Service Bind CRD`
+| `make create-bind`            | Create Mobile Security Service Bind`
+| `make delete-bind`            | Delete Mobile Security Service Bind`
 | `make build`                  | Build operator with its tag`
 | `make publish`                | Publish operator in https://hub.docker.com/[Docker Hub] with its tag`
 | `make build-dev`              | Build operator for development proposes`

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
@@ -2,6 +2,7 @@ apiVersion: mobile-security-service.aerogear.com/v1alpha1
 kind: MobileSecurityServiceBind
 metadata:
   name: mobile-security-service-bind
+  namespace: mobile-security-service-operator
 spec:
   # Add fields here
   size: 1

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: mobile-security-service-bind
+  name: mobile-security-service
 rules:
 - apiGroups:
   - mobile-security-service.aerogear.com
@@ -42,7 +42,8 @@ rules:
 - apiGroups:
   - apps
   resourceNames:
-  - mobile-security-service-bind
+  - mobile-security-service-app
+  - mobile-security-service-db
   resources:
   - deployments/finalizers
   verbs:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,11 +1,11 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: mobile-security-service-bind
+  name: mobile-security-service
 subjects:
 - kind: ServiceAccount
-  name: mobile-security-service-bind
+  name: mobile-security-service
 roleRef:
   kind: Role
-  name: mobile-security-service-bind
+  name: mobile-security-service
   apiGroup: rbac.authorization.k8s.io

--- a/pkg/controller/add_mobilesecurityservicebind.go
+++ b/pkg/controller/add_mobilesecurityservicebind.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/aerogear/mobile-security-service-operator/pkg/controller/mobilesecurityservicebind"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, mobilesecurityservicebind.Add)
+}

--- a/pkg/controller/mobilesecurityservicebind/mobilesecurityservicebind_controller.go
+++ b/pkg/controller/mobilesecurityservicebind/mobilesecurityservicebind_controller.go
@@ -1,0 +1,153 @@
+package mobilesecurityservicebind
+
+import (
+	"context"
+
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("controller_mobilesecurityservicebind")
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+
+// Add creates a new MobileSecurityServiceBind Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileMobileSecurityServiceBind{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("mobilesecurityservicebind-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource MobileSecurityServiceBind
+	err = c.Watch(&source.Kind{Type: &mobilesecurityservicev1alpha1.MobileSecurityServiceBind{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	// TODO(user): Modify this to be the types you create that are owned by the primary resource
+	// Watch for changes to secondary resource Pods and requeue the owner MobileSecurityServiceBind
+	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &mobilesecurityservicev1alpha1.MobileSecurityServiceBind{},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileMobileSecurityServiceBind{}
+
+// ReconcileMobileSecurityServiceBind reconciles a MobileSecurityServiceBind object
+type ReconcileMobileSecurityServiceBind struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a MobileSecurityServiceBind object and makes changes based on the state read
+// and what is in the MobileSecurityServiceBind.Spec
+// TODO(user): Modify this Reconcile function to implement your Controller logic.  This example creates
+// a Pod as an example
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileMobileSecurityServiceBind) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Reconciling MobileSecurityServiceBind")
+
+	// Fetch the MobileSecurityServiceBind instance
+	instance := &mobilesecurityservicev1alpha1.MobileSecurityServiceBind{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// Define a new Pod object
+	pod := newPodForCR(instance)
+
+	// Set MobileSecurityServiceBind instance as the owner and controller
+	if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Check if this Pod already exists
+	found := &corev1.Pod{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, found)
+	if err != nil && errors.IsNotFound(err) {
+		reqLogger.Info("Creating a new Pod", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+		err = r.client.Create(context.TODO(), pod)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// Pod created successfully - don't requeue
+		return reconcile.Result{}, nil
+	} else if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Pod already exists - don't requeue
+	reqLogger.Info("Skip reconcile: Pod already exists", "Pod.Namespace", found.Namespace, "Pod.Name", found.Name)
+	return reconcile.Result{}, nil
+}
+
+// newPodForCR returns a busybox pod with the same name/namespace as the cr
+func newPodForCR(cr *mobilesecurityservicev1alpha1.MobileSecurityServiceBind) *corev1.Pod {
+	labels := map[string]string{
+		"app": cr.Name,
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name + "-pod",
+			Namespace: cr.Namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "busybox",
+					Image:   "busybox",
+					Command: []string{"sleep", "3600"},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8971

## What
- Add a controller for Bind Operations
- Update Readme
- Improve make commands

## Why
This controller will be responsible to watch the CR created by the MDC and do the bind/unbind/re-bind actions

## How
Following the command used to create the controller.
```
operator-sdk add controller --api-version=mobile-security-service.aerogear.com/v1alpha1  --kind=MobileSecurityServiceBind
```

## Verification Steps
* Bulding and publishing the dev-tag (make build-dev & make publish-dev)
* Update the operator.yaml to use the dev tag
* Update the clusterHost cnfig
* Run `make create-all`
* Check that all is working with success
<img width="1497" alt="Screenshot 2019-04-04 at 11 00 18" src="https://user-images.githubusercontent.com/7708031/55547296-e9f36080-56c8-11e9-8b8f-890416f99a92.png">
<img width="1461" alt="Screenshot 2019-04-04 at 11 00 22" src="https://user-images.githubusercontent.com/7708031/55547302-ecee5100-56c8-11e9-98d0-894880036ea7.png">

* Check that the pod test bind was created.
<img width="947" alt="Screenshot 2019-04-04 at 10 59 15" src="https://user-images.githubusercontent.com/7708031/55547251-d0521900-56c8-11e9-9212-32245c31ce73.png">

* Run `make delete-all`
* Check that all was removed with success. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes


