### PR TITLE
feat(BIND) : Add spec and logic to filter by labels specified

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,9 +25,7 @@ toc::[]
 
 == Overview
 
-A https://commons.openshift.org/sig/OpenshiftOperators.html[Operator] based on the https://github.com/operator-framework/operator-sdk[Operator SDK] that installs and maintains https://github.com/aerogear/mobile-security-service[AeroGear Mobile Security Service] on a cluster.
-
-NOTE: This project is a POC
+A https://commons.openshift.org/sig/OpenshiftOperators.html[Operator] based on the https://github.com/operator-framework/operator-sdk[Operator SDK] to manage, install, configure the https://github.com/aerogear/mobile-security-service[Mobile Security Service] on a OpenShift/Kubernetes cluster.
 
 == Prerequisites
 
@@ -43,6 +41,8 @@ NOTE: This project is a POC
 
 === Getting the project
 
+By the following commands you will create a local directory and clone this project.
+
 [source,shell]
 ----
 $ mkdir -p $GOPATH/src/github.com/aerogear/mobile-security-service-operator
@@ -51,7 +51,7 @@ $ git clone https://github.com/aerogear/mobile-security-service-operator.git
 $ cd $GOPATH/src/github.com/aerogear/mobile-security-service-operator
 ----
 
-=== Installing Minishift
+=== Installing on Minishift
 
 https://docs.okd.io/latest/minishift/getting-started/installing.html[Install Minishift] then enable Operators on it by running the following commands.
 
@@ -67,17 +67,6 @@ $ minishift addon enable admin-user
 $ minishift start
 ----
 
-=== Logging as system:admin
-
-To install the operator is required have admin permissions in the cluster.
-
-[source,shell]
-----
-$ oc login -u system:admin
-----
-
-NOTE: This operator will be installed in the cluster level.
-
 === Configuring the Operator
 
 Update the "mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml" with your cluster info. Following the place.
@@ -91,7 +80,7 @@ Update the "mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml" with
   hostSufix: ".nip.io"
 ----
 
-=== Creating Operator, Service and Roles
+=== Installing the Operator, Service and Roles on the cluster
 
 Use the following command.
 
@@ -100,10 +89,9 @@ Use the following command.
 $ make create-all
 ----
 
-IMPORTANT: To apply you need be logged as admin. (`oc login -u system:admin`)
+WARING: To create all you need be logged as admin. Use `oc login -u system:admin`.
 
-
-=== Deleting the Operator, Service and Roles
+=== Removing the Operator, Service and Roles on the cluster
 
 Use the following command.
 
@@ -114,15 +102,21 @@ $ make delete-all
 
 IMPORTANT: To delete you need be logged as admin. (`oc login -u system:admin`)
 
-== Mobile Security Service Application and Database configurations
+== Configurations and Options
 
-The environment variables used in this project are configured by the Config Map which is created by the operator. To have a further understatement over its configuration see https://github.com/aerogear/mobile-security-service#setup-and-configurations[Setup and Configurations] section of https://github.com/aerogear/mobile-security-service[Mobile Security Service].
+=== Environment Variables
 
-TIP: For example, see that the name of the database is mapped in the ConfigMap which is used by Mobile Security Service application and database. Note that to connect to the database with the default values you may use the command: `psql -h localhost -U postgresql mobile_security_service.
+The environment variables are used to configure the https://github.com/aerogear/mobile-security-service[Mobile Security Service] Application and Database. For a further understatement over its configuration see https://github.com/aerogear/mobile-security-service#setup-and-configurations[Setup and Configurations] section in https://github.com/aerogear/mobile-security-service[Mobile Security Service] README.
 
-== Creating Role for no-privilege users are able to create the application and database in their namespaces
+NOTE: All values used in the default configuration came from the config-map which is managed and created by the Operator.
 
-By executing the following commands you will create roles in the cluster which will allow the <user> create the Mobile Security Service Application and Database in their namespaces. However, the Mobile Security Service Operator is cluster scoped and will still only accessible for the system admin users. (E.g `oc login -u system:admin`)
+=== Watch specifications for the MobileSecurityServiceBind (CR)
+
+The Bind watches the applications in the cluster in order to create, delete and update the data in the https://github.com/aerogear/mobile-security-service[Mobile Security Service] by it REST API. It is the CR responsible for "bind/unbind/re-bind" the applications to the Service and by it CR properties which follows you will be able to define what applications should be watched/checked by this operator. For a further understanding check the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml[mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml] file.
+
+=== Role for no-privilege users are able to create the Mobile Security Service App and Database
+
+By executing the following commands you will create roles in the cluster which will allow the <user> create the Mobile Security Service Application and Database in their namespaces. In this would not be required be the system:admin. However, the Mobile Security Service Operator is cluster scoped and will still only accessible for the system admin users. (E.g `oc login -u system:admin`)
 
 [source,shell]
 ----
@@ -159,7 +153,7 @@ NOTE: In this example the tag `0.1.0` will be replaced for the new one.
 
 IMPORTANT: Follow the https://semver.org/[Semantic Versioning] to define the new tags
 
-=== Building and pushing the new version
+=== Building and publish a new version tag in docker.hub
 
 Run the following commands
 

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
@@ -6,3 +6,17 @@ metadata:
 spec:
   # Add fields here
   size: 1
+  # Watch filter setup for the Bind CR
+  # The watchKeyLabelSelector and watchValueLabelSelector defines the label key:value which will be watched by this type
+  # The watchNamespaceSelector defined an specific namespace for be watched by this type
+  # IMPORTANT: If no values be configured here the type will watch in the same namespace where the bind type was applied
+  # NOTES:
+  #     If just the key and label be filled then the bind will check in all namespaces the deployments with them
+  #     If just the watchNamespaceSelector be filled then the bind will consider all from this namespace only
+  #     Also, both can be filled and the filter will be aggregated, in this way the bind will watch the namespace and filter by the key:value selector as well
+  watchKeyLabelSelector: app
+  watchValueLabelSelector: mdc
+  watchNamespaceSelector:
+  # The following attributes defined the key:value label used to inform that the app is bind to the service
+  appKeyLabelSelector: mobilesecurityservice
+  appValueLabelSelector: bind

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservicebind_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservicebind_types.go
@@ -14,6 +14,11 @@ type MobileSecurityServiceBindSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 	Size int32  `json:"size"`
+	WatchKeyLabelSelector string `json:"watchKeyLabelSelector,omitempty"`
+	WatchValueLabelSelector string `json:"watchValueLabelSelector,omitempty"`
+	WatchNamespaceSelector string `json:"watchNamespaceSelector,omitempty"`
+	AppKeyLabelSelector string `json:"appKeyLabelSelector"`
+	AppValueLabelSelector string `json:"appValueLabelSelector"`
 }
 
 // MobileSecurityServiceBindStatus defines the observed state of MobileSecurityServiceBind

--- a/pkg/controller/add_mobilesecurityservicebind.go
+++ b/pkg/controller/add_mobilesecurityservicebind.go
@@ -1,10 +1,11 @@
 package controller
 
 import (
+	"github.com/aerogear/mobile-security-service-operator/pkg/controller/mobilesecurityservice"
 	"github.com/aerogear/mobile-security-service-operator/pkg/controller/mobilesecurityservicebind"
 )
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, mobilesecurityservicebind.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, mobilesecurityservicebind.Add,  mobilesecurityservice.Add)
 }

--- a/pkg/controller/mobilesecurityservice/controller.go
+++ b/pkg/controller/mobilesecurityservice/controller.go
@@ -25,7 +25,6 @@ import (
 const (
 	CONFIGMAP     = "ConfigMap"
 	DEEPLOYMENT   = "Deployment"
-	SDK_CONFIGMAP = "SDKConfigMap"
 	SERVICE       = "Service"
 	INGRESS       = "Ingress"
 )
@@ -128,8 +127,6 @@ func buildObject(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.
 	switch kind {
 	case CONFIGMAP:
 		return r.buildAppConfigMap(instance), nil
-	case SDK_CONFIGMAP:
-		return r.buildAppSDKConfigMap(instance), nil
 	case DEEPLOYMENT:
 		return r.buildAppDeployment(instance), nil
 	case SERVICE:
@@ -182,14 +179,6 @@ func (r *ReconcileMobileSecurityService) Reconcile(request reconcile.Request) (r
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, service)
 	if err != nil {
 		return create(r, instance, reqLogger, SERVICE, err)
-	}
-
-	//Check if the SDK ConfigMap already exists, if not create a new one
-	configmapsdk := &corev1.ConfigMap{}
-	configmapsdk_name := instance.Name + "-sdk"
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: configmapsdk_name, Namespace: instance.Namespace}, configmapsdk)
-	if err != nil {
-		return create(r, instance, reqLogger, SDK_CONFIGMAP, err)
 	}
 
 	//Check if the deployment already exists, if not create a new one

--- a/pkg/controller/mobilesecurityservice/helpers.go
+++ b/pkg/controller/mobilesecurityservice/helpers.go
@@ -27,7 +27,6 @@ func getAppIngressHost(m *mobilesecurityservicev1alpha1.MobileSecurityService) s
 	return hostName;
 }
 
-
 //To transform the object into a string with its json
 func getSdkConfigStringJsonFormat(sdk *models.SDKConfig) string{
 	jsonSdk, _ := json.Marshal(sdk)
@@ -36,23 +35,6 @@ func getSdkConfigStringJsonFormat(sdk *models.SDKConfig) string{
 	buf.ReadFrom(res)
 	b := buf.Bytes()
 	return *(*string)(unsafe.Pointer(&b))
-}
-
-//TODO: Implement this func to get all services available for this project when/if it started to have services
-func getServices() []models.SDKConfigService{
-	//service := *models.NewSDKConfigServices("","")
-	res := []models.SDKConfigService{}
-	//res = append(res, service)
-	return res
-}
-
-// return properties for the response SDK
-func getConfigMapSDKForMobileSecurityService(m *mobilesecurityservicev1alpha1.MobileSecurityService) map[string]string {
-	url:= "http://" + getAppIngressHost(m)
-	sdk := models.NewSDKConfig(m, url, getServices())
-	return map[string]string{
-		"SDKConfig": getSdkConfigStringJsonFormat(sdk),
-	}
 }
 
 // Helper to build the env vars which will be configured in the deployment of the Mobile Security Service Project

--- a/pkg/controller/mobilesecurityservicebind/configmaps.go
+++ b/pkg/controller/mobilesecurityservicebind/configmaps.go
@@ -1,4 +1,4 @@
-package mobilesecurityservice
+package mobilesecurityservicebind
 
 import (
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
@@ -8,19 +8,20 @@ import (
 )
 
 // Returns the ConfigMap with the properties used to setup/config the Mobile Security Service Project
-func (r *ReconcileMobileSecurityService) buildAppConfigMap(m *mobilesecurityservicev1alpha1.MobileSecurityService) *corev1.ConfigMap {
-	ls := getAppLabels(m.Name)
+func (r *ReconcileMobileSecurityServiceBind) buildAppBindSDKConfigMap(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind, mss *mobilesecurityservicev1alpha1.MobileSecurityService) *corev1.ConfigMap {
+	ls := getAppLabelsForSDKConfigMap(m.Name)
+	name := m.Name + "-sdk"
 	ser := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      m.Name,
+			Name:      name,
 			Namespace: m.Namespace,
 			Labels:    ls,
 		},
-		Data: getAppEnvVarsMap(m),
+		Data: getConfigMapSDKForMobileSecurityService(mss),
 	}
 	// Set MobileSecurityService instance as the owner and controller
 	controllerutil.SetControllerReference(m, ser, r.scheme)

--- a/pkg/controller/mobilesecurityservicebind/helpers.go
+++ b/pkg/controller/mobilesecurityservicebind/helpers.go
@@ -1,0 +1,107 @@
+package mobilesecurityservicebind
+
+import (
+	"bytes"
+	"encoding/json"
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	"github.com/aerogear/mobile-security-service-operator/pkg/models"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"unsafe"
+)
+
+
+// Returns an string map with the labels which wil be associated to the kubernetes/openshift objects
+// which will be created and managed by this operator
+func getAppLabels(name string) map[string]string {
+	return map[string]string{"app": "mobilesecurityservice", "mobilesecurityservicebind_cr": name}
+}
+
+func getAppLabelsSelectorMDCApp(labelSelector, valueSelector string) map[string]string {
+	return map[string]string{labelSelector: valueSelector}
+}
+
+func getAppLabelsForSDKConfigMap(name string) map[string]string {
+	return map[string]string{"app": "mobilesecurityservice", "mobilesecurityservicebind_cr": name, "name": name+"-sdk-config"}
+}
+
+// getPodNames returns the pod names of the array of pods passed in
+func getPodNames(pods []corev1.Pod) []string {
+	var podNames []string
+	for _, pod := range pods {
+		podNames = append(podNames, pod.Name)
+	}
+	return podNames
+}
+
+// It will build the HOST for the router/ingress created for the Mobile Security Service App
+func getAppIngressHost(m *mobilesecurityservicev1alpha1.MobileSecurityService) string {
+	hostName := m.Name + "-" + m.Namespace + "." + m.Spec.ClusterHost + m.Spec.HostSufix
+	return hostName;
+}
+
+
+//To transform the object into a string with its json
+func getSdkConfigStringJsonFormat(sdk *models.SDKConfig) string{
+	jsonSdk, _ := json.Marshal(sdk)
+	res:= strings.NewReader(string(jsonSdk))
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(res)
+	b := buf.Bytes()
+	return *(*string)(unsafe.Pointer(&b))
+}
+
+//TODO: Implement this func to get all services available for this project when/if it started to have services
+func getServices() []models.SDKConfigService{
+	//service := *models.NewSDKConfigServices("","")
+	res := []models.SDKConfigService{}
+	//res = append(res, service)
+	return res
+}
+
+// return properties for the response SDK
+func getConfigMapSDKForMobileSecurityService(m *mobilesecurityservicev1alpha1.MobileSecurityService) map[string]string {
+	url:= "http://" + getAppIngressHost(m)
+	sdk := models.NewSDKConfig(m, url, getServices())
+	return map[string]string{
+		"SDKConfig": getSdkConfigStringJsonFormat(sdk),
+	}
+}
+// return true when the key and label spec are filled
+func hasWatchLabelSelectors(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind) bool {
+	if len(m.Spec.WatchKeyLabelSelector) > 0 && len(m.Spec.WatchValueLabelSelector) > 0  {
+		return true
+	}
+	return false
+}
+
+// return true when the namespace spec is filled
+func hasWatchNamespaceSelector(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind) bool {
+	if len(m.Spec.WatchNamespaceSelector) > 0 {
+		return true
+	}
+	return false
+}
+
+//Return the List with Ops to tell what resources the Bind should watch
+func getWatchListOps(instance *mobilesecurityservicev1alpha1.MobileSecurityServiceBind, reqLogger logr.Logger) client.ListOptions {
+	var listOps client.ListOptions
+	labelSelector := labels.SelectorFromSet(getAppLabelsSelectorMDCApp(instance.Spec.WatchKeyLabelSelector, instance.Spec.WatchValueLabelSelector))
+	if hasWatchLabelSelectors(instance) && hasWatchNamespaceSelector(instance) {
+		reqLogger.Info("Watching by WatchNamespaceSelector and by the WatchLabelSelectors ...")
+		listOps = client.ListOptions{Namespace: instance.Spec.WatchNamespaceSelector, LabelSelector: labelSelector}
+	} else if hasWatchLabelSelectors(instance) && !hasWatchNamespaceSelector(instance) {
+		reqLogger.Info("Watching by WatchLabelSelectors only ...")
+		listOps = client.ListOptions{LabelSelector: labelSelector}
+	} else if !hasWatchLabelSelectors(instance) && hasWatchNamespaceSelector(instance) {
+		reqLogger.Info("Watching by WatchNamespaceSelector only ...")
+		listOps = client.ListOptions{Namespace: instance.Spec.WatchNamespaceSelector}
+	} else {
+		reqLogger.Info("Not found Specification for Watch Labels or Namespace. Watching in the same namespace where the BIND is installed ...")
+		listOps = client.ListOptions{Namespace: instance.Namespace}
+	}
+	return listOps
+}

--- a/pkg/controller/mobilesecurityservicebind/watches.go
+++ b/pkg/controller/mobilesecurityservicebind/watches.go
@@ -1,0 +1,28 @@
+package mobilesecurityservicebind
+
+import (
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+//Watch for changes to secondary resources and create the owner MobileSecurityService
+//Watch ConfigMap objects created in the project/namespace
+func watchConfigMap(c controller.Controller) error {
+	err := c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &mobilesecurityservicev1alpha1.MobileSecurityServiceBind{},
+	})
+	return err
+}
+
+//TODO: Check if it will be or not really required
+func watchPod(c controller.Controller) error {
+	err := c.Watch(&source.Kind{Type:&corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &mobilesecurityservicev1alpha1.MobileSecurityServiceBind{},
+	})
+	return err
+}


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8912

## What
- Impl logic to allow spec the labels and/or namespaces which should be watched by the BIND
- Impl logic to allow spec the label(key:value) to define that the app should be managed by the BIND. It means that the app/pod is "bind" to the service.
 - Add info into README and improved it.

## Why
- Allow reducing the scope which should be watched by the bind in order to improve performance
- Allow the bind knows what app is managed or not by the MDC and should be part of the action to bind/unbind/rebind to MSS by the Operator
- Allow specific labels by the attributes in the CR. 

## How
- Create specs in type api
- Impl controller to filter based on the specs defined.  

## Verification Steps

1. Build and publish the dev tag ( make build-dev and make publish-dev)
2. Setup your local env to use the dev tag ( change it in the deploy/operator.ymal )
3. Run `make create-all`
4. Ensure that all in running with success 

### Checking/Testing the options
Following an explanation to allow you to do these tests. 

* Note that the default value set up in this CR is as follows. 

```yaml
  watchKeyLabelSelector: app
  watchValueLabelSelector: mdc
  watchNamespaceSelector:
```

* Note that you can create the app/pod which will be watched here by the Browser Catalog and choose a NodeJS app. Click on the advanced options as you can check in the following images to add the labels. 

<img width="867" alt="Screenshot 2019-04-04 at 17 42 28" src="https://user-images.githubusercontent.com/7708031/55573153-38bcec80-5701-11e9-9712-111ffabd1afb.png">
<img width="1042" alt="Screenshot 2019-04-04 at 17 42 35" src="https://user-images.githubusercontent.com/7708031/55573152-38bcec80-5701-11e9-9781-8582714a2881.png">

### By BindType/Controller watching key: value labels

* Create a pod in the cluster which has the label `app: mdc` (default value)
* Check in `mobile-security-service-operator project >> Monitor >> Operator logs` the logs as found [here](https://github.com/aerogear/mobile-security-service-operator/pull/24/files#diff-1e489743622fb12881fae56a164a41e9R161) to see if the pod was found.  

### By BindType/Controller watching key:value labels and namespace
* Create a new namespace project
* Create a new pod in the latest namespace created which has the label `app: mdc` (default value)
* Add the namespace in the CR config 
* Run `make delete-all and make create-all`
* Check in `mobile-security-service-operator project >> Monitor >> Operator logs` the logs as found [here](https://github.com/aerogear/mobile-security-service-operator/pull/24/files#diff-1e489743622fb12881fae56a164a41e9R161) to see if the pod was found.  

### By BindType/Controller watching namespace only
* Create a new namespace project
* Create a new pod in the latest namespace 
* Add the namespace in the CR config and remove the watchKeyLabelSelector and watchValueLabelSelector
* Run `make delete-all and make create-all`
* Check in `mobile-security-service-operator project >> Monitor >> Operator logs` the logs as found [here](https://github.com/aerogear/mobile-security-service-operator/pull/24/files#diff-1e489743622fb12881fae56a164a41e9R161) to see if the pod was found.  

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<img width="1268" alt="Screenshot 2019-04-05 at 11 51 20" src="https://user-images.githubusercontent.com/7708031/55622904-68b7ce80-5799-11e9-90fc-8c6c11d025b3.png">
