### PR TITLE
Customize the make delete-all in order to not show log errors for the user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,19 @@ create-all:
 .PHONY: delete-all
 delete-all:
 	@echo Delete Mobile Security Service Operator, Service and namespace "mobile-security-service-operator":
-	make delete-oper
-	make delete-app
-	make delete-bind
+	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
+	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
+	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
+	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
+	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_crd.yaml
+	- kubectl delete -f deploy/cluster_role.yaml
+	- kubectl delete -f deploy/cluster_role_binding.yaml
+	- kubectl delete -f deploy/service_account.yaml
+	- kubectl delete -f deploy/operator.yaml
+	- kubectl delete -f deploy/role.yaml
+	- kubectl delete -f deploy/role_binding.yaml
+	- kubectl delete namespace mobile-security-service-operator
 
 .PHONY: create-oper
 create-oper:


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8988

## What
Customize the make delete-all in order to not show log errors for the user

Following an example of the msg.
```
Deleting Mobile Security Service and Database:
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
Error from server (NotFound): error when deleting "deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml": the server could not find the requested resource (delete mobilesecurityservices.mobile-security-service.aerogear.com mobile-security-service-app)
make[1]: [delete-app] Error 1 (ignored)
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
Error from server (NotFound): error when deleting "deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml": the server could not find the requested resource (delete mobilesecurityservicedbs.mobile-security-service.aerogear.com mobile-security-service-db)
make[1]: [delete-app] Error 1 (ignored)
make delete-bind
Deleting Mobile Security Service Bind:
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
Error from server (NotFound): error when deleting "deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml": the server could not find the requested resource (delete mobilesecurityservicebinds.mobile-security-service.aerogear.com mobile-security-service-bind)
make[1]: *** [delete-bind] Error 1
make: [delete-all] Error 2 (ignored)
kubectl delete namespace mobile-security-service-operator
namespace "mobile-security-service-operator" deleted
```

## Why
Better user experience. 

## Verification Steps
* Run the `make create-all` and `make delete-all` and no errors should appears. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
```
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (master) $ make create-all
Create Mobile Security Service Operator and Service in the namespace mobile-security-service-operator:
make create-oper
Create Mobile Security Service Operator:
kubectl create namespace mobile-security-service-operator
namespace/mobile-security-service-operator created
kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
customresourcedefinition.apiextensions.k8s.io/mobilesecurityservices.mobile-security-service.aerogear.com created
kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
customresourcedefinition.apiextensions.k8s.io/mobilesecurityservicedbs.mobile-security-service.aerogear.com created
kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_crd.yaml
customresourcedefinition.apiextensions.k8s.io/mobilesecurityservicebinds.mobile-security-service.aerogear.com created
kubectl create -f deploy/cluster_role.yaml
clusterrole.rbac.authorization.k8s.io/mobile-security-service-operator created
kubectl create -f deploy/cluster_role_binding.yaml
clusterrolebinding.rbac.authorization.k8s.io/mobile-security-service-operator created
kubectl create -f deploy/role.yaml
role.rbac.authorization.k8s.io/mobile-security-service created
kubectl create -f deploy/role_binding.yaml
rolebinding.rbac.authorization.k8s.io/mobile-security-service created
kubectl create -f deploy/service_account.yaml
serviceaccount/mobile-security-service-operator created
kubectl create -f deploy/operator.yaml
deployment.apps/mobile-security-service-operator created
make create-app
Creating Mobile Security Service and Database into project:
kubectl apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
mobilesecurityservice.mobile-security-service.aerogear.com/mobile-security-service-app created
kubectl apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
mobilesecurityservicedb.mobile-security-service.aerogear.com/mobile-security-service-db created
make create-bind
Creating Mobile Security Service Bind:
kubectl apply -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
mobilesecurityservicebind.mobile-security-service.aerogear.com/mobile-security-service-bind created
camilamacedo@Camilas-MacBook-Pro ~/go/src/github.com/aerogear/mobile-security-service-operator (master) $ make delete-all
Delete Mobile Security Service Operator, Service and namespace mobile-security-service-operator:
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
mobilesecurityservice.mobile-security-service.aerogear.com "mobile-security-service-app" deleted
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
mobilesecurityservicedb.mobile-security-service.aerogear.com "mobile-security-service-db" deleted
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
mobilesecurityservicebind.mobile-security-service.aerogear.com "mobile-security-service-bind" deleted
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
customresourcedefinition.apiextensions.k8s.io "mobilesecurityservices.mobile-security-service.aerogear.com" deleted
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
customresourcedefinition.apiextensions.k8s.io "mobilesecurityservicedbs.mobile-security-service.aerogear.com" deleted
kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_crd.yaml
customresourcedefinition.apiextensions.k8s.io "mobilesecurityservicebinds.mobile-security-service.aerogear.com" deleted
kubectl delete -f deploy/cluster_role.yaml
clusterrole.rbac.authorization.k8s.io "mobile-security-service-operator" deleted
kubectl delete -f deploy/cluster_role_binding.yaml
clusterrolebinding.rbac.authorization.k8s.io "mobile-security-service-operator" deleted
kubectl delete -f deploy/service_account.yaml
serviceaccount "mobile-security-service-operator" deleted
kubectl delete -f deploy/operator.yaml
deployment.apps "mobile-security-service-operator" deleted
kubectl delete -f deploy/role.yaml
role.rbac.authorization.k8s.io "mobile-security-service" deleted
kubectl delete -f deploy/role_binding.yaml
rolebinding.rbac.authorization.k8s.io "mobile-security-service" deleted
kubectl delete namespace mobile-security-service-operator
namespace "mobile-security-service-operator" deleted
```