### PR TITLE
Aerogear 9044 - Make the name of the configMap can be specified

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -105,6 +105,13 @@ The environment variables are used to configure the https://github.com/aerogear/
 
 NOTE: All values used in the default configuration came from the config-map which is managed and created by the Operator.
 
+=== Config Map Name to store Environment Variables values
+
+The Mobile Security Service CRD will create the configMap to store these values. The name of the configMap is specified in ./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService].
+
+NOTE: If the name of this ConfigMap be not specified then the name of the Mobile Security Service instance will be used instead of.
+NOTE: The link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml[MobileSecurityServiceDB] and ./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService] should specified the same name for this ConfigMap in order to allow the App and Database share its usage.
+
 === Watch specifications for the MobileSecurityServiceBind (CR)
 
 The Bind watches the applications in the cluster in order to create, delete and update the data in the https://github.com/aerogear/mobile-security-service[Mobile Security Service] by it REST API. It is the CR responsible for "bind/unbind/re-bind" the applications to the Service and by it CR properties which follows you will be able to define what applications should be watched/checked by this operator. For a further understanding check the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml[mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml] file.
@@ -226,8 +233,6 @@ NOTE: The image/tag used from https://github.com/aerogear/mobile-security-servic
 | `make delete-all`             | Delete mobile-security-service-operator namespace, operator, service and roles
 | `make create-oper`            | Create mobile-security-service namespace, operator and roles
 | `make delete-oper`            | Delete mobile-security-service namespace, operator and roles
-| `make create-olm`             | Create mobile-security-service namespace, catalogue operator(olm) and roles
-| `make delete-olm`             | Delete mobile-security-service namespace, catalogue operator(olm) and roles
 | `make create-app`             | Create Mobile Security Service App and its database in the project
 | `make create-app-only`        | Create Mobile Security Service App without its database
 | `make delete-app`             | Delete Mobile Security Service App and its database

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
@@ -28,4 +28,11 @@ spec:
   # - Replace "{{clusterHost}}" for your cluster HOST. E.g 192.168.64.9
   # - You can use "$ oc status | grep server" or "kubectl cluster-info" to get this cluster info
   clusterHost: "{{clusterHost}}"
+  # The hostSufix will be used to created the route/ingress
   hostSufix: ".nip.io"
+  # The configMapName define the configMap which should be created and used in order to
+  # get the values of the Env Variables created by the Mobile Security Service controller.
+  # NOTE:
+  #    If this ConfigMap be not found the default values defined above will be used directly instead of.
+  #    If the name be nt specified then it will be the Mobile Security Service instance name.
+  configMapName: "mss-config"

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
@@ -20,3 +20,11 @@ spec:
   # The following attributes defined the key:value label used to inform that the app is bind to the service
   appKeyLabelSelector: mobilesecurityservice
   appValueLabelSelector: bind
+  # The following data will be used to do requests using the ingress/route created for the Mobile Security Service App
+  # NOTE:
+  # - Replace "{{clusterHost}}" for your cluster HOST. E.g 192.168.64.9
+  # - You can use "$ oc status | grep server" or "kubectl cluster-info" to get this cluster info
+  # IMPORTANT: The clusterHost and hostSufix need to be the same values configured in the mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+  clusterHost: "{{clusterHost}}"
+  # The hostSufix which was used to created the route/ingress
+  hostSufix: ".nip.io"

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
@@ -19,4 +19,5 @@ spec:
   # The configMapName define the configMap which should be used in order to
   # get the values of the Env Variables created by the Mobile Security Service Database deployment,
   # However, if this ConfigMap be not found the default values defined above will be used instead of
-  configMapName: "mobile-security-service-app"
+  # IMPORTANT: The configMapName should be the same specified in the Mobile Security Service CR
+  configMapName: "mss-config"

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservice_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservice_types.go
@@ -29,6 +29,7 @@ type MobileSecurityServiceSpec struct {
 	AccessControlAllowCredentials string `json:"accessControlAllowCredentials"`
 	ClusterHost                   string `json:"clusterHost"`
 	HostSufix                     string `json:"hostSufix"`
+	ConfigMapName                 string `json:"configMapName,omitempty"`
 }
 
 // MobileSecurityServiceStatus defines the observed state of MobileSecurityService

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservicebind_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservicebind_types.go
@@ -19,6 +19,8 @@ type MobileSecurityServiceBindSpec struct {
 	WatchNamespaceSelector string `json:"watchNamespaceSelector,omitempty"`
 	AppKeyLabelSelector string `json:"appKeyLabelSelector"`
 	AppValueLabelSelector string `json:"appValueLabelSelector"`
+	ClusterHost                   string `json:"clusterHost"`
+	HostSufix                     string `json:"hostSufix"`
 }
 
 // MobileSecurityServiceBindStatus defines the observed state of MobileSecurityServiceBind

--- a/pkg/controller/add_mobilesecurityservicebind.go
+++ b/pkg/controller/add_mobilesecurityservicebind.go
@@ -1,11 +1,10 @@
 package controller
 
 import (
-	"github.com/aerogear/mobile-security-service-operator/pkg/controller/mobilesecurityservice"
 	"github.com/aerogear/mobile-security-service-operator/pkg/controller/mobilesecurityservicebind"
 )
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, mobilesecurityservicebind.Add,  mobilesecurityservice.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, mobilesecurityservicebind.Add)
 }

--- a/pkg/controller/mobilesecurityservice/configmaps.go
+++ b/pkg/controller/mobilesecurityservice/configmaps.go
@@ -9,16 +9,15 @@ import (
 
 // Returns the ConfigMap with the properties used to setup/config the Mobile Security Service Project
 func (r *ReconcileMobileSecurityService) buildAppConfigMap(m *mobilesecurityservicev1alpha1.MobileSecurityService) *corev1.ConfigMap {
-	ls := getAppLabels(m.Name)
 	ser := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      m.Name,
+			Name:      getConfigMapName(m),
 			Namespace: m.Namespace,
-			Labels:    ls,
+			Labels:    getAppLabels(m.Name),
 		},
 		Data: getAppEnvVarsMap(m),
 	}

--- a/pkg/controller/mobilesecurityservice/controller.go
+++ b/pkg/controller/mobilesecurityservice/controller.go
@@ -169,7 +169,7 @@ func (r *ReconcileMobileSecurityService) Reconcile(request reconcile.Request) (r
 
 	//Check if the ConfigMap already exists, if not create a new one
 	configMap := &corev1.ConfigMap{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, configMap)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.ConfigMapName, Namespace: instance.Namespace}, configMap)
 	if err != nil {
 		return create(r, instance, reqLogger, CONFIGMAP, err)
 	}

--- a/pkg/controller/mobilesecurityservice/helpers.go
+++ b/pkg/controller/mobilesecurityservice/helpers.go
@@ -17,13 +17,22 @@ func getAppLabels(name string) map[string]string {
 	return map[string]string{"app": "mobilesecurityservice", "mobilesecurityservice_cr": name}
 }
 
+// Returns an string name with the name of the configMap
+func getConfigMapName(m *mobilesecurityservicev1alpha1.MobileSecurityService) string{
+	if len(m.Spec.ConfigMapName) > 0 {
+		return m.Spec.ConfigMapName
+	}
+	return m.Name
+}
+
 func getAppLabelsForSDKConfigMap(name string) map[string]string {
 	return map[string]string{"app": "mobilesecurityservice", "mobilesecurityservice_cr": name, "name": name+"-sdk-config"}
 }
 
+//TODO: Centralized
 // It will build the HOST for the router/ingress created for the Mobile Security Service App
 func getAppIngressHost(m *mobilesecurityservicev1alpha1.MobileSecurityService) string {
-	hostName := m.Name + "-" + m.Namespace + "." + m.Spec.ClusterHost + m.Spec.HostSufix
+	hostName := "mobile-security-service-app" + "." + m.Spec.ClusterHost + m.Spec.HostSufix
 	return hostName;
 }
 
@@ -46,7 +55,7 @@ func buildAppEnvVars(m *mobilesecurityservicev1alpha1.MobileSecurityService) *[]
 			ValueFrom: &corev1.EnvVarSource{
 				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: m.Name,
+						Name: getConfigMapName(m),
 					},
 					Key: key,
 				},

--- a/pkg/controller/mobilesecurityservicebind/configmaps.go
+++ b/pkg/controller/mobilesecurityservicebind/configmaps.go
@@ -8,9 +8,9 @@ import (
 )
 
 // Returns the ConfigMap with the properties used to setup/config the Mobile Security Service Project
-func (r *ReconcileMobileSecurityServiceBind) buildAppBindSDKConfigMap(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind, mss *mobilesecurityservicev1alpha1.MobileSecurityService) *corev1.ConfigMap {
+func (r *ReconcileMobileSecurityServiceBind) buildAppBindSDKConfigMap(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind, pod corev1.Pod) *corev1.ConfigMap {
 	ls := getAppLabelsForSDKConfigMap(m.Name)
-	name := m.Name + "-sdk"
+	name := pod.Name + "-sdk"
 	ser := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -18,10 +18,10 @@ func (r *ReconcileMobileSecurityServiceBind) buildAppBindSDKConfigMap(m *mobiles
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: m.Namespace,
+			Namespace: pod.Namespace,
 			Labels:    ls,
 		},
-		Data: getConfigMapSDKForMobileSecurityService(mss),
+		Data: getConfigMapSDKForMobileSecurityService(m),
 	}
 	// Set MobileSecurityService instance as the owner and controller
 	controllerutil.SetControllerReference(m, ser, r.scheme)

--- a/pkg/controller/mobilesecurityservicebind/helpers.go
+++ b/pkg/controller/mobilesecurityservicebind/helpers.go
@@ -37,13 +37,6 @@ func getPodNames(pods []corev1.Pod) []string {
 	return podNames
 }
 
-// It will build the HOST for the router/ingress created for the Mobile Security Service App
-func getAppIngressHost(m *mobilesecurityservicev1alpha1.MobileSecurityService) string {
-	hostName := m.Name + "-" + m.Namespace + "." + m.Spec.ClusterHost + m.Spec.HostSufix
-	return hostName;
-}
-
-
 //To transform the object into a string with its json
 func getSdkConfigStringJsonFormat(sdk *models.SDKConfig) string{
 	jsonSdk, _ := json.Marshal(sdk)
@@ -63,7 +56,7 @@ func getServices() []models.SDKConfigService{
 }
 
 // return properties for the response SDK
-func getConfigMapSDKForMobileSecurityService(m *mobilesecurityservicev1alpha1.MobileSecurityService) map[string]string {
+func getConfigMapSDKForMobileSecurityService(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind) map[string]string {
 	url:= "http://" + getAppIngressHost(m)
 	sdk := models.NewSDKConfig(m, url, getServices())
 	return map[string]string{
@@ -105,3 +98,15 @@ func getWatchListOps(instance *mobilesecurityservicev1alpha1.MobileSecurityServi
 	}
 	return listOps
 }
+
+//TODO: Centralized
+// It will build the HOST for the router/ingress created for the Mobile Security Service App
+func getAppIngressHost(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind) string {
+	hostName := "mobile-security-service-app" + "." + m.Spec.ClusterHost + m.Spec.HostSufix
+	return hostName;
+}
+
+func getURLServiceRestAPI(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind) string {
+	return getAppIngressHost(m) + "/api/"
+}
+

--- a/pkg/models/sdkConfig.go
+++ b/pkg/models/sdkConfig.go
@@ -12,7 +12,7 @@ type SDKConfig struct{
 	Services              []SDKConfigService `json:"services,omitempty"`
 }
 
-func NewSDKConfig(m *mobilesecurityservicev1alpha1.MobileSecurityService, host string, services []SDKConfigService) *SDKConfig {
+func NewSDKConfig(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind, host string, services []SDKConfigService) *SDKConfig {
 	cfg := new(SDKConfig)
 	cfg.Name = m.Name
 	cfg.Namespace = m.Namespace


### PR DESCRIPTION
## Motivation
- https://issues.jboss.org/browse/AEROGEAR-9044

## What
- Make the name of the configMap can be specified
- Also improvements in the route/ingress name
- Update README with the info

## Why
- Users should be able to specify it
- Make easier to use 

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Build and publish the dev version
2. Run make create-all to install the dev image
3. Check that the configMap will be created and used by the APP and DB with the specified name
4. Check if the route still be created with success and is working. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
 
<img width="1071" alt="Screenshot 2019-04-08 at 12 41 03" src="https://user-images.githubusercontent.com/7708031/55721607-a9af1d80-59fb-11e9-866b-ab1f7344d716.png">
<img width="1490" alt="Screenshot 2019-04-08 at 12 40 50" src="https://user-images.githubusercontent.com/7708031/55721609-aa47b400-59fb-11e9-84ad-535b6ba39b94.png">
<img width="994" alt="Screenshot 2019-04-08 at 12 34 48" src="https://user-images.githubusercontent.com/7708031/55721610-aa47b400-59fb-11e9-9fbf-eae87d40556f.png">



