### PR TITLE
feat(bind) : Creating configMap for the pods and removing fixed protocol

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -71,7 +71,7 @@ $ minishift start
 
 === Configuring
 
-Update the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml] with your cluster/host IP.
+Update the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml] and the file link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml[mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml] with your cluster/host IP.
 
 NOTE: The `clusterHost` will be used to generated the route/ingress source as in the ConfigMap created with the SDK JSON config.
 
@@ -105,7 +105,7 @@ The environment variables are used to configure the https://github.com/aerogear/
 
 NOTE: All values used in the default configuration came from the config-map which is managed and created by the Operator.
 
-=== Config Map Name to store Environment Variables values
+=== ConfigMap Name to store Environment Variables values
 
 The Mobile Security Service CRD will create the configMap to store these values. The name of the configMap is specified in ./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService].
 
@@ -115,6 +115,12 @@ NOTE: The link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityserv
 === Watch specifications for the MobileSecurityServiceBind (CR)
 
 The Bind watches the applications in the cluster in order to create, delete and update the data in the https://github.com/aerogear/mobile-security-service[Mobile Security Service] by it REST API. It is the CR responsible for "bind/unbind/re-bind" the applications to the Service and by it CR properties which follows you will be able to define what applications should be watched/checked by this operator. For a further understanding check the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml[mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml] file.
+
+=== Key labels which store the name and ID of the applications
+
+In the The link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebiind_cr.yaml[MobileSecurityServiceBind] you can find the specifications `appNameLabel` and `appIdLabel` which defined the labels to store the values. The name and id of the application is used to synchronized this data with the https://github.com/aerogear/mobile-security-service[Mobile Security Service].
+
+NOTE: The default values are `app` and `appId`
 
 === Role for no-privilege users are able to create the Mobile Security Service App and Database
 

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
@@ -29,6 +29,7 @@ spec:
   # - You can use "$ oc status | grep server" or "kubectl cluster-info" to get this cluster info
   clusterHost: "{{clusterHost}}"
   # The hostSufix will be used to created the route/ingress
+  protocol: "http"
   hostSufix: ".nip.io"
   # The configMapName define the configMap which should be created and used in order to
   # get the values of the Env Variables created by the Mobile Security Service controller.

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebind_cr.yaml
@@ -14,7 +14,7 @@ spec:
   #     If just the key and label be filled then the bind will check in all namespaces the deployments with them
   #     If just the watchNamespaceSelector be filled then the bind will consider all from this namespace only
   #     Also, both can be filled and the filter will be aggregated, in this way the bind will watch the namespace and filter by the key:value selector as well
-  watchKeyLabelSelector: app
+  watchKeyLabelSelector: owner
   watchValueLabelSelector: mdc
   watchNamespaceSelector:
   # The following attributes defined the key:value label used to inform that the app is bind to the service
@@ -26,5 +26,10 @@ spec:
   # - You can use "$ oc status | grep server" or "kubectl cluster-info" to get this cluster info
   # IMPORTANT: The clusterHost and hostSufix need to be the same values configured in the mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
   clusterHost: "{{clusterHost}}"
+  protocol: "http"
   # The hostSufix which was used to created the route/ingress
   hostSufix: ".nip.io"
+  # The appNameLabel spec defines the key label which will have the name of the app
+  appNameLabel: "app"
+  # The appIdLabel spec defines the key label which will have the id of the app
+  appIdLabel: "appId"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: mobile-security-service-operator
           # Replace this with the built image name
-          image: aerogear/mobile-security-service-operator:0.1.0
+          image: aerogear/mobile-security-service-operator:0.1.0-dev
           command:
           - mobile-security-service-operator
           imagePullPolicy: Always

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservice_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservice_types.go
@@ -29,7 +29,9 @@ type MobileSecurityServiceSpec struct {
 	AccessControlAllowCredentials string `json:"accessControlAllowCredentials"`
 	ClusterHost                   string `json:"clusterHost"`
 	HostSufix                     string `json:"hostSufix"`
+	Protocol                      string `json:"protocol"`
 	ConfigMapName                 string `json:"configMapName,omitempty"`
+
 }
 
 // MobileSecurityServiceStatus defines the observed state of MobileSecurityService

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservicebind_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservicebind_types.go
@@ -21,6 +21,9 @@ type MobileSecurityServiceBindSpec struct {
 	AppValueLabelSelector string `json:"appValueLabelSelector"`
 	ClusterHost                   string `json:"clusterHost"`
 	HostSufix                     string `json:"hostSufix"`
+	Protocol                      string `json:"protocol"`
+	AppNameLabel                  string `json:"appNameLabel"`
+	AppIdLabel                    string `json:"appIdLabel"`
 }
 
 // MobileSecurityServiceBindStatus defines the observed state of MobileSecurityServiceBind

--- a/pkg/controller/mobilesecurityservice/helpers.go
+++ b/pkg/controller/mobilesecurityservice/helpers.go
@@ -29,13 +29,6 @@ func getAppLabelsForSDKConfigMap(name string) map[string]string {
 	return map[string]string{"app": "mobilesecurityservice", "mobilesecurityservice_cr": name, "name": name+"-sdk-config"}
 }
 
-//TODO: Centralized
-// It will build the HOST for the router/ingress created for the Mobile Security Service App
-func getAppIngressHost(m *mobilesecurityservicev1alpha1.MobileSecurityService) string {
-	hostName := "mobile-security-service-app" + "." + m.Spec.ClusterHost + m.Spec.HostSufix
-	return hostName;
-}
-
 //To transform the object into a string with its json
 func getSdkConfigStringJsonFormat(sdk *models.SDKConfig) string{
 	jsonSdk, _ := json.Marshal(sdk)
@@ -78,13 +71,4 @@ func getAppEnvVarsMap(m *mobilesecurityservicev1alpha1.MobileSecurityService) ma
 		"PGPASSWORD":                       m.Spec.DatabasePassword,
 		"PGUSER":                           m.Spec.DatabaseUser,
 	}
-}
-
-// getPodNames returns the pod names of the array of pods passed in
-func getPodNames(pods []corev1.Pod) []string {
-	var podNames []string
-	for _, pod := range pods {
-		podNames = append(podNames, pod.Name)
-	}
-	return podNames
 }

--- a/pkg/controller/mobilesecurityservice/ingress.go
+++ b/pkg/controller/mobilesecurityservice/ingress.go
@@ -2,6 +2,7 @@ package mobilesecurityservice
 
 import (
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -29,7 +30,7 @@ func (r *ReconcileMobileSecurityService) buildAppIngress(m *mobilesecurityservic
 			},
 			Rules: []v1beta1.IngressRule{
 				{
-					Host: getAppIngressHost(m),
+					Host: utils.GetAppIngress(m.Spec.ClusterHost, m.Spec.HostSufix),
 					IngressRuleValue: v1beta1.IngressRuleValue{
 						HTTP: &v1beta1.HTTPIngressRuleValue{
 							Paths: []v1beta1.HTTPIngressPath{

--- a/pkg/controller/mobilesecurityservicebind/configmaps.go
+++ b/pkg/controller/mobilesecurityservicebind/configmaps.go
@@ -2,6 +2,7 @@ package mobilesecurityservicebind
 
 import (
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -9,21 +10,19 @@ import (
 
 // Returns the ConfigMap with the properties used to setup/config the Mobile Security Service Project
 func (r *ReconcileMobileSecurityServiceBind) buildAppBindSDKConfigMap(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind, pod corev1.Pod) *corev1.ConfigMap {
-	ls := getAppLabelsForSDKConfigMap(m.Name)
-	name := pod.Name + "-sdk"
-	ser := &corev1.ConfigMap{
+	configMap := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      utils.GetAppNameByPodLabel(pod, m),
 			Namespace: pod.Namespace,
-			Labels:    ls,
+			Labels:    getAppLabelsForSDKConfigMap(m.Name),
 		},
-		Data: getConfigMapSDKForMobileSecurityService(m),
+		Data: getConfigMapSDKForMobileSecurityService(m, pod),
 	}
 	// Set MobileSecurityService instance as the owner and controller
-	controllerutil.SetControllerReference(m, ser, r.scheme)
-	return ser
+	controllerutil.SetControllerReference(m, configMap, r.scheme)
+	return configMap
 }

--- a/pkg/controller/mobilesecurityservicebind/watches.go
+++ b/pkg/controller/mobilesecurityservicebind/watches.go
@@ -18,7 +18,6 @@ func watchConfigMap(c controller.Controller) error {
 	return err
 }
 
-//TODO: Check if it will be or not really required
 func watchPod(c controller.Controller) error {
 	err := c.Watch(&source.Kind{Type:&corev1.Pod{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,

--- a/pkg/controller/mobilesecurityservicedb/helpers.go
+++ b/pkg/controller/mobilesecurityservicedb/helpers.go
@@ -83,12 +83,3 @@ func (r *ReconcileMobileSecurityServiceDB) getDatabasePasswordEnvVar(m *mobilese
 		Value: m.Spec.DatabasePassword,
 	}
 }
-
-// getPodNames returns the pod names of the array of pods passed in
-func getPodNames(pods []corev1.Pod) []string {
-	var podNames []string
-	for _, pod := range pods {
-		podNames = append(podNames, pod.Name)
-	}
-	return podNames
-}

--- a/pkg/models/configService.go
+++ b/pkg/models/configService.go
@@ -1,0 +1,12 @@
+package models
+
+
+type ConfigService struct{
+	MobileSecurityServiceURL string `json:"mobile-security-server-url"`
+}
+
+func NewConfigService(url string) *ConfigService {
+	service := new (ConfigService)
+	service.MobileSecurityServiceURL = url
+	return service
+}

--- a/pkg/models/sdkConfig.go
+++ b/pkg/models/sdkConfig.go
@@ -2,21 +2,34 @@ package models
 
 import (
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type SDKConfig struct{
-	Version 			  string     `json:"name"`
+	Version 			  string     `json:"version"`
 	Name                  string     `json:"name"`
 	Namespace             string     `json:"namespace"`
 	Host             	  string     `json:"host"`
+	ClientID              string     `json:"clientId"`
 	Services              []SDKConfigService `json:"services,omitempty"`
 }
 
-func NewSDKConfig(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind, host string, services []SDKConfigService) *SDKConfig {
+func NewSDKConfig(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind, pod corev1.Pod) *SDKConfig {
+
 	cfg := new(SDKConfig)
-	cfg.Name = m.Name
-	cfg.Namespace = m.Namespace
-	cfg.Host = host
-	cfg.Services = services
+	cfg.Version = "1.0.0"
+	cfg.Name = utils.GetAppNameByPodLabel(pod, m)
+	cfg.Namespace = pod.Namespace
+	cfg.Host = m.Spec.ClusterHost
+	cfg.Services = getServices(m)
 	return cfg
+}
+
+//return the Service data for the SDK ConfigMap
+func getServices(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind) []SDKConfigService{
+	service := *NewSDKConfigServices(m)
+	res := []SDKConfigService{}
+	res = append(res, service)
+	return res
 }

--- a/pkg/models/sdkConfigService.go
+++ b/pkg/models/sdkConfigService.go
@@ -1,13 +1,35 @@
 package models
 
+import (
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
+)
+
+const (
+	ID = "security"
+	Name = "security"
+	Type = "security"
+)
+
 type SDKConfigService struct{
+	ID					  string     `json:"id"`
 	Name                  string     `json:"name"`
-	Host             	  string     `json:"host"`
+	Type                  string     `json:"type"`
+	URL             	  string     `json:"url"`
+	ConfigService         ConfigService `json:"config,omitempty"`
 }
 
-func NewSDKConfigServices(serviceName, serviceHost string) *SDKConfigService {
+func NewSDKConfigServices(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind) *SDKConfigService {
 	service := new(SDKConfigService)
-	service.Name = serviceName
-	service.Host = serviceHost
+	service.ID = ID
+	service.Name = Name
+	service.Type = Type
+	service.URL = utils.GetAppIngressURL(m.Spec.Protocol, m.Spec.ClusterHost, m.Spec.HostSufix)
+	service.ConfigService = *NewConfigService(service.URL)
 	return service
 }
+
+
+
+
+

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+)
+
+const APP_URL =  "mobile-security-service-app"
+
+func GetAppIngressURL(protocol, host, hostSufix string) string {
+	return protocol +"://" + APP_URL + "." + host + hostSufix
+}
+
+func GetAppIngress(host, hostSufix string) string {
+	return APP_URL + "." + host + hostSufix
+}
+
+// getPodNames returns the pod names of the array of pods passed in
+func GetPodNames(pods []corev1.Pod) []string {
+	var podNames []string
+	for _, pod := range pods {
+		podNames = append(podNames, pod.Name)
+	}
+	return podNames
+}
+
+//Get the App Name according to the label key specified in the CR
+func GetAppNameByPodLabel(pod corev1.Pod, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceBind) string {
+	return pod.GetLabels()[instance.Spec.AppNameLabel]
+}
+
+//Get the App ID according to the label key specified in the CR
+func GetAppIdByPodLabel(pod corev1.Pod, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceBind) string {
+	return pod.GetLabels()[instance.Spec.AppIdLabel]
+}


### PR DESCRIPTION
## Motivation
* https://issues.jboss.org/browse/AEROGEAR-9041
* https://issues.jboss.org/browse/AEROGEAR-8993

## What
- Make the protocol (HTTP or HTTPS) be configured by the spec
- Create ConfigMap for the Bind app in the Cluster
- Make ConfigMap be created in the spec used in the SDK 
- Improve logs 

## Why
- Users should be able to get the JSON to config the SDK by the configMap
- Users should be able to define the cluster protocol 
- Easier to monitor and check what is happing

## Verification Steps
* Build and Publish the operator dev tag (`make build-dev and make publish-dev`)
* Config the CRS with the local clusterHost
* Install the operator by the command `make create-all`
* Create a new namespace/project to test the changes (E.g `$ oc new-project managemdc `)

### Check that the ConfigMap was created when should be 
* Create an app with the required labels:
<img width="1234" alt="Screenshot 2019-04-09 at 22 03 18" src="https://user-images.githubusercontent.com/7708031/55835748-904dc480-5b14-11e9-82d8-83182d3ba583.png">
<img width="1034" alt="Screenshot 2019-04-09 at 21 55 01" src="https://user-images.githubusercontent.com/7708031/55835750-904dc480-5b14-11e9-9c8e-91d21cee4306.png">

* Check that the configMap should be created for this case

### Check that the ConfigMap was NOT created when should NOT be 

* Create an app with the required labels:

<img width="920" alt="Screenshot 2019-04-09 at 22 03 27" src="https://user-images.githubusercontent.com/7708031/55835746-8fb52e00-5b14-11e9-9e13-08ff0ea15683.png">

* Check that the configMap should NOT be created for this case

Following the result expected.

<img width="1604" alt="Screenshot 2019-04-09 at 22 55 55" src="https://user-images.githubusercontent.com/7708031/55837957-c8580600-5b1a-11e9-8fbd-61c14ba14574.png">

<img width="1603" alt="Screenshot 2019-04-09 at 22 55 44" src="https://user-images.githubusercontent.com/7708031/55837958-c8580600-5b1a-11e9-91a2-7d48a2b0c6ba.png">

### Check if configMap will be re-created
* Remove the configMap and check that after few minutes the operator will recreate it. 

### Check the Route
* Ensure that the router was created and that still be possible to check the UI. 

<img width="1586" alt="Screenshot 2019-04-09 at 22 58 04" src="https://user-images.githubusercontent.com/7708031/55838017-f6d5e100-5b1a-11e9-987d-3a13f1dd028f.png">

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
