### PR TITLE
feat(Bind) : Creating new apps by REST API (AEROGEAR-8914)

### DIFF
--- a/pkg/models/app.go
+++ b/pkg/models/app.go
@@ -17,3 +17,5 @@ func NewApp(m *mobilesecurityservicev1alpha1.MobileSecurityServiceBind, pod core
 	app.AppID = utils.GetAppIdByPodLabel(pod, m)
 	return app
 }
+
+//TODO: It should be removed when the PR: https://github.com/aerogear/mobile-security-service/pull/145 be merged

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -33,3 +33,7 @@ func GetAppNameByPodLabel(pod corev1.Pod, instance *mobilesecurityservicev1alpha
 func GetAppIdByPodLabel(pod corev1.Pod, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceBind) string {
 	return pod.GetLabels()[instance.Spec.AppIdLabel]
 }
+
+func GetRestAPIForApps(instance *mobilesecurityservicev1alpha1.MobileSecurityServiceBind) string {
+	return GetAppIngressURL(instance) + "/api/apps"
+}


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-8914

## What
When the watch/monitor find out the app with the respective criteria then the binding should be called.

## Why
The apps should be created by the operator

## How
Impl in the Bind Controller

## Verification Steps
 
1. Build, Publish and Config and install the dev tag of the operator
2. Create a new namespace/project ( oc new-project test )
3. By the OCP catalogue create an app with the labels which will tell for the Operator that the app is bind to the service. Following the image. 

<img width="1034" alt="Screenshot 2019-04-09 at 21 55 01" src="https://user-images.githubusercontent.com/7708031/55876090-aef0a180-5b8e-11e9-9f70-5a3b53a80f93.png">

 
4. Check via postman that the app was created with the app name and ID stored in the labels.

<img width="781" alt="Screenshot 2019-04-10 at 12 40 01" src="https://user-images.githubusercontent.com/7708031/55876014-7fda3000-5b8e-11e9-8ebe-9ea562437755.png">


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 
