### PR TITLE
Use RedHat image DB + update readme with its configurable infos + make the params can be specified by the spec

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -162,6 +162,10 @@ $ oc create rolebinding developer-mobile-security-service-operator --role=mobile
 $ oc create rolebinding developer-mobile-security-service --role=mobile-security-service --user=<user>
 ----
 
+=== Database image and parameters
+
+The database image and its parameters as their default values are configurable and specified by the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml[MobileSecurityServiceDB CR].
+
 == Development
 
 === Architecture
@@ -299,6 +303,8 @@ $ make build
 $ make publish
 ----
 
+NOTE: You need be logged in the docker and have access to publish images on it. Use `$ docker login`.
+
 ==== Dev tags
 
 The dev tags will allow you test locally the changes performed in the project without affect the tag published into the https://hub.docker.com/r/aerogear/mobile-security-service-operator[Docker Hub] based on the master branch. The following commands will build the project and publish it with the tag which will be <version>-dev.
@@ -308,6 +314,8 @@ The dev tags will allow you test locally the changes performed in the project wi
 $ make build-dev
 $ make publish-dev
 ----
+
+NOTE: You need be logged in the docker and have access to publish images on it. Use `$ docker login`.
 
 === Using the dev tags
 

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
@@ -5,13 +5,18 @@ metadata:
   namespace: mobile-security-service-operator
 spec:
   size: 1
-  image: "postgres:9.6"
+  # The imaged used in this project is from Red Hat. See more in https://docs.okd.io/latest/using_images/db_images/postgresql.html
+  image: "centos/postgresql-96-centos7"
   containerName: "database"
   # Following the default values for the Env Variables which will be created by the operator
   # for the Mobile Security Service Database deployment
   databaseName: "mobile_security_service"
   databasePassword: "postgres"
   databaseUser: "postgresql"
+  # Following are the args which will be used as the key label for the environment variable of the database image.
+  databaseNameParam: "POSTGRESQL_DATABASE"
+  databasePasswordParam: "POSTGRESQL_PASSWORD"
+  databaseUserParam: "POSTGRESQL_USER"
   databasePort: 5432
   databaseMemoryLimit: "512Mi"
   databaseMemoryRequest: "512Mi"

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservicedb_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservicedb_types.go
@@ -22,6 +22,9 @@ type MobileSecurityServiceDBSpec struct {
 	DatabaseName           string `json:"databaseName"`
 	DatabasePassword       string `json:"databasePassword"`
 	DatabaseUser           string `json:"databaseUser"`
+	DatabaseNameParam      string `json:"databaseNameParam"`
+	DatabasePasswordParam  string `json:"databasePasswordParam"`
+	DatabaseUserParam      string `json:"databaseUserParam"`
 	DatabasePort           int32  `json:"databasePort"`
 	DatabaseMemoryLimit    string `json:"databaseMemoryLimit"`
 	DatabaseMemoryRequest  string `json:"databaseMemoryRequest"`

--- a/pkg/controller/mobilesecurityservicedb/deployments.go
+++ b/pkg/controller/mobilesecurityservicedb/deployments.go
@@ -60,28 +60,11 @@ func (r *ReconcileMobileSecurityServiceDB) buildDBDeployment(m *mobilesecurityse
 								MountPath: "/var/lib/pgsql/data",
 							},
 						},
-						ReadinessProbe: &corev1.Probe{
-							Handler: corev1.Handler{
-								Exec: &corev1.ExecAction{
-									Command: []string{
-										"pg_isready",
-										"-h",
-										"localhost",
-										"-U",
-										m.Spec.DatabaseUser,
-									},
-								},
-							},
-							InitialDelaySeconds: 5,
-							TimeoutSeconds:      1,
-						},
 						LivenessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
 								Exec: &corev1.ExecAction{
 									Command: []string{
 										"pg_isready",
-										"-h",
-										"localhost",
 										"-U",
 										m.Spec.DatabaseUser,
 									},

--- a/pkg/controller/mobilesecurityservicedb/helpers.go
+++ b/pkg/controller/mobilesecurityservicedb/helpers.go
@@ -14,7 +14,7 @@ func getDBLabels(name string) map[string]string {
 func (r *ReconcileMobileSecurityServiceDB) getDatabaseNameEnvVar(m *mobilesecurityservicev1alpha1.MobileSecurityServiceDB) corev1.EnvVar {
 	if r.hasAppConfigMap(m) {
 		return corev1.EnvVar{
-			Name: "POSTGRES_DB",
+			Name: m.Spec.DatabaseNameParam,
 			ValueFrom: &corev1.EnvVarSource{
 				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -27,7 +27,7 @@ func (r *ReconcileMobileSecurityServiceDB) getDatabaseNameEnvVar(m *mobilesecuri
 	}
 
 	return corev1.EnvVar{
-		Name:  "POSTGRES_DB",
+		Name:  m.Spec.DatabaseNameParam,
 		Value: m.Spec.DatabaseName,
 	}
 }
@@ -45,7 +45,7 @@ func (r *ReconcileMobileSecurityServiceDB) hasAppConfigMap(m *mobilesecurityserv
 func (r *ReconcileMobileSecurityServiceDB) getDatabaseUserEnvVar(m *mobilesecurityservicev1alpha1.MobileSecurityServiceDB) corev1.EnvVar {
 	if r.hasAppConfigMap(m) {
 		return corev1.EnvVar{
-			Name: "POSTGRES_USER",
+			Name: m.Spec.DatabaseUserParam,
 			ValueFrom: &corev1.EnvVarSource{
 				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -58,7 +58,7 @@ func (r *ReconcileMobileSecurityServiceDB) getDatabaseUserEnvVar(m *mobilesecuri
 	}
 
 	return corev1.EnvVar{
-		Name:  "POSTGRES_USER",
+		Name:  m.Spec.DatabaseUserParam,
 		Value: m.Spec.DatabaseUser,
 	}
 }
@@ -66,7 +66,7 @@ func (r *ReconcileMobileSecurityServiceDB) getDatabaseUserEnvVar(m *mobilesecuri
 func (r *ReconcileMobileSecurityServiceDB) getDatabasePasswordEnvVar(m *mobilesecurityservicev1alpha1.MobileSecurityServiceDB) corev1.EnvVar {
 	if r.hasAppConfigMap(m) {
 		return corev1.EnvVar{
-			Name: "POSTGRES_PASSWORD",
+			Name: m.Spec.DatabasePasswordParam,
 			ValueFrom: &corev1.EnvVarSource{
 				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -79,7 +79,7 @@ func (r *ReconcileMobileSecurityServiceDB) getDatabasePasswordEnvVar(m *mobilese
 	}
 
 	return corev1.EnvVar{
-		Name:  "POSTGRES_PASSWORD",
+		Name:  m.Spec.DatabasePasswordParam,
 		Value: m.Spec.DatabasePassword,
 	}
 }


### PR DESCRIPTION
## Motivation
* https://issues.jboss.org/browse/AEROGEAR-8962
* https://issues.jboss.org/browse/AEROGEAR-9042

## What
* Setup it to use the RedHat image
* Make the parameters name be configurable by the DB CR spec
* Solve errors in the logs 
* update the readme with the info

## Why
* we should use the redhat image instead of the public one which is ensured by the company
* better user experience
* make the project more flexible and configurable each image/version defined some name for the default args for the database be created.

## Verification Steps
1. Build, publish, config and install the build-dev image. Update local env to use the dev image.
2. Install the operator and all ( make create-all )
3. Check if the database will be installed and get running with success
4. Check if service is running with success
5. Bind and unbind some app and check the result in the UI and/or postman
6. Delete the deployment of the db and after the operator re-creates it checks if the data inserted into the db still there.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<img width="1574" alt="Screenshot 2019-04-16 at 11 28 26" src="https://user-images.githubusercontent.com/7708031/56202368-c6baa080-603a-11e9-9bb9-8dd6370a9a34.png">
<img width="1597" alt="Screenshot 2019-04-16 at 11 28 17" src="https://user-images.githubusercontent.com/7708031/56202369-c6baa080-603a-11e9-8855-00baf7e79493.png">
<img width="729" alt="Screenshot 2019-04-16 at 11 28 09" src="https://user-images.githubusercontent.com/7708031/56202370-c7533700-603a-11e9-8992-b6cd6e1fb4b3.png">
 
