### PR TITLE
Small adjustment - Upper the time to get the ConfigMap and add info in the README 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -170,6 +170,10 @@ The database image and its parameters as their default values are configurable a
 
 === Architecture
 
+This operator is `cluster-scoped`. To know more over it see the topic https://github.com/operator-framework/operator-sdk/blob/master/doc/user-guide.md#operator-scope[Operator Scope] in the Operator Framework documentation. Also, check its roles in link:./deploy/[Deploy] directory.
+
+NOTE: The operator, application and database will be installed in the namespace `mobile-security-service-operator` which will be created by this project.
+
 ==== CRD Definitions
 
 |===

--- a/pkg/controller/mobilesecurityservicedb/controller.go
+++ b/pkg/controller/mobilesecurityservicedb/controller.go
@@ -149,7 +149,7 @@ func (r *ReconcileMobileSecurityServiceDB) Reconcile(request reconcile.Request) 
 	if err != nil {
 		// To give time for the mobile security service CRD controller create the configMap which will be used for both.
 		// If the configMap be not found it will created with the default values specified in its CR for the env variables
-		time.Sleep(5 * time.Second)
+		time.Sleep(10 * time.Second)
 		return r.create(instance, reqLogger, DEEPLOYMENT, err)
 	}
 


### PR DESCRIPTION
## Motivation
* https://github.com/aerogear/mobile-security-service-operator/pull/44

## What
* upper the time to 10 instead of 5. 
* add info over operator scope and namespace to the readme

## Why
* has some scenarios that 5 seconds is not enough because it worked fine with the dev image but now with a new cluster has not. 
 
## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
