### PR TITLE
fix(AEROGEAR-9093) - Error: configmaps mss-config not found and Probes

### DIFF
--- a/pkg/controller/mobilesecurityservice/deployments.go
+++ b/pkg/controller/mobilesecurityservice/deployments.go
@@ -60,11 +60,11 @@ func (r *ReconcileMobileSecurityService) buildAppDeployment(m *mobilesecurityser
 									Scheme: corev1.URISchemeHTTP,
 								},
 							},
-							InitialDelaySeconds: 10,
-							FailureThreshold:    3,
-							TimeoutSeconds:      10,
-							PeriodSeconds:       10,
-							SuccessThreshold:    1,
+							FailureThreshold: 3,
+							InitialDelaySeconds: 5,
+							PeriodSeconds: 10,
+							TimeoutSeconds:      1,
+							SuccessThreshold: 1,
 						},
 						LivenessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
@@ -77,11 +77,11 @@ func (r *ReconcileMobileSecurityService) buildAppDeployment(m *mobilesecurityser
 									Scheme: corev1.URISchemeHTTP,
 								},
 							},
-							InitialDelaySeconds: 10,
-							FailureThreshold:    3,
+							FailureThreshold: 3,
+							InitialDelaySeconds: 120,
+							PeriodSeconds: 10,
 							TimeoutSeconds:      10,
-							PeriodSeconds:       10,
-							SuccessThreshold:    1,
+							SuccessThreshold: 1,
 						},
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{

--- a/pkg/controller/mobilesecurityservice/fetches.go
+++ b/pkg/controller/mobilesecurityservice/fetches.go
@@ -52,7 +52,7 @@ func (r *ReconcileMobileSecurityService) fetchAppDeployment(reqLogger logr.Logge
 func (r *ReconcileMobileSecurityService) fetchAppConfigMap(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService) (*corev1.ConfigMap, error) {
 	reqLogger.Info("Checking if the ConfigMap already exists")
 	configMap := &corev1.ConfigMap{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Spec.ConfigMapName, Namespace: instance.Namespace}, configMap)
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: getConfigMapName(instance), Namespace: instance.Namespace}, configMap)
 	return configMap, err
 }
 

--- a/pkg/controller/mobilesecurityservicedb/deployments.go
+++ b/pkg/controller/mobilesecurityservicedb/deployments.go
@@ -64,14 +64,32 @@ func (r *ReconcileMobileSecurityServiceDB) buildDBDeployment(m *mobilesecurityse
 							Handler: corev1.Handler{
 								Exec: &corev1.ExecAction{
 									Command: []string{
-										"pg_isready",
-										"-U",
-										m.Spec.DatabaseUser,
+										"/usr/libexec/check-container",
+										"'--live'",
 									},
 								},
 							},
+							FailureThreshold: 3,
 							InitialDelaySeconds: 120,
+							PeriodSeconds: 10,
 							TimeoutSeconds:      10,
+							SuccessThreshold: 1,
+
+						},
+						ReadinessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								Exec: &corev1.ExecAction{
+									Command: []string{
+										"/usr/libexec/check-container",
+									},
+								},
+							},
+							FailureThreshold: 3,
+							InitialDelaySeconds: 5,
+							PeriodSeconds: 10,
+							TimeoutSeconds:      1,
+							SuccessThreshold: 1,
+
 						},
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{

--- a/pkg/controller/mobilesecurityservicedb/helpers.go
+++ b/pkg/controller/mobilesecurityservicedb/helpers.go
@@ -18,7 +18,7 @@ func (r *ReconcileMobileSecurityServiceDB) getDatabaseNameEnvVar(m *mobilesecuri
 			ValueFrom: &corev1.EnvVarSource{
 				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: m.Spec.ConfigMapName,
+						Name: getConfigMapName(m),
 					},
 					Key: "PGDATABASE",
 				},
@@ -35,7 +35,7 @@ func (r *ReconcileMobileSecurityServiceDB) getDatabaseNameEnvVar(m *mobilesecuri
 //Check if has App Config Map created
 func (r *ReconcileMobileSecurityServiceDB) hasAppConfigMap(m *mobilesecurityservicev1alpha1.MobileSecurityServiceDB) bool {
 	configMap := &corev1.ConfigMap{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: m.Spec.ConfigMapName, Namespace: m.Namespace}, configMap)
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: getConfigMapName(m), Namespace: m.Namespace}, configMap)
 	if err != nil {
 		return false
 	}
@@ -49,7 +49,7 @@ func (r *ReconcileMobileSecurityServiceDB) getDatabaseUserEnvVar(m *mobilesecuri
 			ValueFrom: &corev1.EnvVarSource{
 				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: m.Spec.ConfigMapName,
+						Name: getConfigMapName(m),
 					},
 					Key: "PGUSER",
 				},
@@ -70,7 +70,7 @@ func (r *ReconcileMobileSecurityServiceDB) getDatabasePasswordEnvVar(m *mobilese
 			ValueFrom: &corev1.EnvVarSource{
 				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: m.Spec.ConfigMapName,
+						Name: getConfigMapName(m),
 					},
 					Key: "PGPASSWORD",
 				},
@@ -82,4 +82,12 @@ func (r *ReconcileMobileSecurityServiceDB) getDatabasePasswordEnvVar(m *mobilese
 		Name:  m.Spec.DatabasePasswordParam,
 		Value: m.Spec.DatabasePassword,
 	}
+}
+
+//getConfigMapName returns an string name with the name of the configMap
+func getConfigMapName(m *mobilesecurityservicev1alpha1.MobileSecurityServiceDB) string{
+	if len(m.Spec.ConfigMapName) > 0 {
+		return m.Spec.ConfigMapName
+	}
+	return m.Name
 }


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9093

## What
* Fix the bug which was faced after a while because the DB was not founding the configMap with the values for env variables. 
* Improve and fix the probes for the DB and Service
 
## Why
Fix issues and probes to work with centos/redhat db image. 

## How
Ensure that all places will be looking for the correct name.

## Verification Steps
1. Clone the project, set up the Minishift, set up the mobile-security-service CR with the master VIP.  
2. Use the dev image `cmacedo/mobile-security-service-operator:AEROGEAR-9093-dev`. For it updates the `operator.yaml` file with this value
3. Run `make create-all` and check if all will be started with success. Also, check if the DB env variables are getting the values from the config map created to share it `mss-config`
4. Leave the instance running for a while, like 30 minutes,  then check if all still ok and if the env variables still using the ConfigMap values and no error as follows will be faced.

<img width="1449" alt="Screenshot 2019-04-26 at 10 24 20" src="https://user-images.githubusercontent.com/7708031/56799052-fa9e7e80-680f-11e9-9947-888fa4f800b9.png">


## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<img width="1597" alt="Screenshot 2019-04-26 at 16 20 37" src="https://user-images.githubusercontent.com/7708031/56818298-3f8dd980-683f-11e9-80a7-c29a8ae78a1a.png">
