### PR TITLE
feat(ci): adds image build and push to ci (AEROGEAR-8955)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,45 @@ jobs:
       - run: make test
       - run: make build_linux
 
+  image_push_master:
+    working_directory: /go/src/github.com/aerogear/mobile-security-service-operator
+    docker:
+      - image: circleci/golang:1.10
+    steps:
+      - checkout
+      - run: 
+          name: Install dep
+          command: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+      - run:
+          name: Install operator-sdk to build image
+          command: curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.5.0/operator-sdk-v0.5.0-x86_64-linux-gnu && chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin/
+      - run: make setup
+      # circle ci key required for docker builds
+      - setup_remote_docker
+      - run: make build_linux 
+      - run: make build-master
+      - run: make push-master
+
+  image_release:
+    working_directory: /go/src/github.com/aerogear/mobile-security-service-operator
+    docker:
+      - image: circleci/golang:1.10
+    steps:
+      - checkout
+      - run: 
+          name: Install dep
+          command: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+      - run:
+          name: Install operator-sdk to build image
+          command: curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.6.0/operator-sdk-v0.6.0-x86_64-linux-gnu && chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin/
+      - run: make setup
+      # circle ci key required for docker builds
+      - setup_remote_docker
+      - run: make build-release
+      - run: make push-release
+      - run: make build-latest
+      - run: make push-latest
+
 workflows:
   version: 2
   build:
@@ -26,3 +65,18 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - image_push_master:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+      - image_release:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /\d{1,2}\.\d{1,2}\.\d{1,2}/
+            branches:
+              ignore: /.*/

--- a/README.adoc
+++ b/README.adoc
@@ -320,62 +320,41 @@ debug the project using the following Visual Code launch config.
 
 === Publishing a new version
 
-The tags are published into the https://hub.docker.com/r/aerogear/mobile-security-service-operator[Docker Hub].
+To publish a new version of the operator:
 
-==== Master tags
+- bump the version TAG in the link:./Makefile[Makefile].
+- bump the version in the link:./version/version.go[version.go] file.
+- update the version number in the link:./deploy/operator.yaml[operator.yaml].
+- update the link:./CHANGELOG.md[CHANGELOG.md]
+- add a git tag to the commit you wish to build the release from
+- push the tag to github (this will trigger an automated release by the CI)
 
-To publish an new version of this operator based on the master branch following the steps.
+Note: https://semver.org/[Semantic Versioning] should be followed.
 
-* Update the operator tag version
-+
-Replace the tag of the image in the link:./deploy/operator.yaml[operator.yaml] file.
-+
-[source,yaml]
-----
-  # Replace this with the built image name
-  image: aerogear/mobile-security-service-operator:0.1.0
-----
-+
-NOTE: In this example the tag `0.1.0` will be replaced for the new one.
-+
-* Replace the tag in the link:./Makefile[Makefile] file.
-+
-[source,shell]
-----
-TAG=0.1.0
-----
-+
-NOTE: In this example the tag `0.1.0` will be replaced for the new one.
-+
-IMPORTANT: Follow the https://semver.org/[Semantic Versioning] to define the new tags
-+
-* Build and publish the new version tag in Docker Hub
-+
-Run the following commands
-+
-[source,shell]
-----
-$ make build
-$ make publish
-----
+Images for the mobile-security-service-operator are published to https://quay.io/repository/aerogear/mobile-security-service-operator[Quay.io].
 
-NOTE: You need be logged in the docker and have access to publish images on it. Use `$ docker login`.
+==== Automated image publishing
 
-==== Dev tags
+- For every change merged to master a new image with the `master` tag is published
+- For every change merged that has a git tag a new image with the `<operator-version>` and `latest` tags are published
 
-The dev tags will allow you test locally the changes performed in the project without affect the tag published into the https://hub.docker.com/r/aerogear/mobile-security-service-operator[Docker Hub] based on the master branch. The following commands will build the project and publish it with the tag which will be <version>-dev.
+If the image does not get built and pushed automatically the job may be re-run manually via the https://circleci.com/gh/aerogear/mobile-security-service-operator[CI dashboard]. 
+
+==== Dev images
+
+The following commands will build the project and publish it to `quay.io/aerogear/mobile-security-service-operator` with the tag <version>-dev.
 
 [source,shell]
 ----
 $ make build-dev
-$ make publish-dev
+$ make push-dev
 ----
 
-NOTE: You need be logged in the docker and have access to publish images on it. Use `$ docker login`.
+NOTE: You will require `quay.io` credentials and access to publish images to the `quay.io/aerogear` organisation.
 
 === Using the dev tags
 
-Update the image tag in the file link:./deploy/operator.yaml[operator.yaml] with the development tag as follows.
+To use the dev image update the image in the file link:./deploy/operator.yaml[operator.yaml] with the development tag as follows.
 
 [source,yaml]
 ----
@@ -401,10 +380,8 @@ NOTE: The image/tag used from https://github.com/aerogear/mobile-security-servic
 | `make delete-db-only`         | Delete Mobile Security Service Database only
 | `make create-app`             | Create the Bind CR and delete the Unbind CR examples. (Create/Update app in the Service and add SKD ConfigMap)
 | `make unbind`                 | Delete the Bind CR and create Unbind CR examples. (Delete app from the Service and SDKConfigMap)
-| `make build`                  | Build operator with its tag
-| `make publish`                | Publish operator in https://hub.docker.com/[Docker Hub] with its tag
 | `make build-dev`              | Build operator for development proposes
-| `make publish-dev`            | Publish operator in https://hub.docker.com/[Docker Hub] for development proposes
+| `make push-dev`               | Publish operator in https://hub.docker.com/[Docker Hub] for development proposes
 | `make run-local`              | Run the operator locally for development purposes
 | `make debug-setup`            | Setup environment for debug proposes
 | `make vet`                    | Examines source code and reports suspicious constructs using https://golang.org/cmd/vet/[vet]


### PR DESCRIPTION
## Motivation
AEROGEAR-8955

## What
Update Circle CI config to build and push images

## Why
Add CD

## How
Add steps to Makefile and circle CI config for the building and pushing of images

## Verification Steps

**Verification has already been verified - as per below comment:**

```
I've just finished testing this on my local fork, and can verify the following:
- CI build step works as expected (see CI check in this PR to confirm)
- CI builds and releases a new image whenever changes are merged to master
  - `master` image [here](https://cloud.docker.com/repository/docker/murchu/mobile-security-service-operator/tags) were built and deployed by CI
- CI builds and releases a new image with the version tag, ie `0.1.0`, and also an image with the `latest` tag also, if any pushed commit has a git tag attached
  - - `0.1.0` and `latest` images [here](https://cloud.docker.com/repository/docker/murchu/mobile-security-service-operator/tags) were built and deployed by CI

As discussed, docs updates will be included in [this task](https://issues.jboss.org/browse/AEROGEAR-9078).
```

### Make commands:
* Run ` $ make test-integration-cover`

```
$ make test-integration-cover
echo "mode: count" > coverage-all.out
GOCACHE=off
```

* Run `$ make build-master`

```
$ make build-master
Building operator with the tag docker.io/aerogear/mobile-security-service-operator:master:
operator-sdk build docker.io/aerogear/mobile-security-service-operator:master
INFO[0001] Building Docker image docker.io/aerogear/mobile-security-service-operator:master 
Sending build context to Docker daemon  245.4MB
Step 1/7 : FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:7.6
 ---> 1f8526ca508d
Step 2/7 : ENV OPERATOR=/usr/local/bin/mobile-security-service-operator     USER_UID=1001     USER_NAME=mobile-security-service-operator
 ---> Using cache
 ---> e37d7a7f8754
Step 3/7 : COPY build/_output/bin/mobile-security-service-operator ${OPERATOR}
 ---> Using cache
 ---> 8398b56fa75e
Step 4/7 : COPY build/bin /usr/local/bin
 ---> Using cache
 ---> fa2a044fa198
Step 5/7 : RUN  /usr/local/bin/user_setup
 ---> Using cache
 ---> e779e3c5cb94
Step 6/7 : ENTRYPOINT ["/usr/local/bin/entrypoint"]
 ---> Using cache
 ---> 1519a626f9f4
Step 7/7 : USER ${USER_UID}
 ---> Using cache
 ---> 3c596be4ccaa
Successfully built 3c596be4ccaa
Successfully tagged aerogear/mobile-security-service-operator:master
INFO[0007] Operator build complete.                     
```

* Run `$make push-master`

```
$ make push-master
Publishing operator in aerogear/mobile-security-service-operator with the tag master:
docker push docker.io/aerogear/mobile-security-service-operator:master
The push refers to repository [docker.io/aerogear/mobile-security-service-operator]
df4a9f3f573e: Layer already exists 
4971ec651589: Layer already exists 
e3b3ca70bb46: Layer already exists 
48eeec1f62af: Layer already exists 
5bfa1c2bc41d: Layer already exists 
```

* Run `$ make build-release`

```
$ make build-release
Building operator with the tag docker.io/aerogear/mobile-security-service-operator:0.1.0:
operator-sdk build docker.io/aerogear/mobile-security-service-operator:0.1.0
INFO[0001] Building Docker image docker.io/aerogear/mobile-security-service-operator:0.1.0 
Sending build context to Docker daemon  245.4MB
Step 1/7 : FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:7.6
 ---> 1f8526ca508d
Step 2/7 : ENV OPERATOR=/usr/local/bin/mobile-security-service-operator     USER_UID=1001     USER_NAME=mobile-security-service-operator
 ---> Using cache
 ---> e37d7a7f8754
Step 3/7 : COPY build/_output/bin/mobile-security-service-operator ${OPERATOR}
 ---> Using cache
 ---> 8398b56fa75e
Step 4/7 : COPY build/bin /usr/local/bin
 ---> Using cache
 ---> fa2a044fa198
Step 5/7 : RUN  /usr/local/bin/user_setup
 ---> Using cache
 ---> e779e3c5cb94
Step 6/7 : ENTRYPOINT ["/usr/local/bin/entrypoint"]
 ---> Using cache
 ---> 1519a626f9f4
Step 7/7 : USER ${USER_UID}
 ---> Using cache
 ---> 3c596be4ccaa
Successfully built 3c596be4ccaa
Successfully tagged aerogear/mobile-security-service-operator:0.1.0
INFO[0006] Operator build complete.                     
```

* Run `$ make push-release`

```
 $ make push-release
Publishing operator in aerogear/mobile-security-service-operator with the tag 0.1.0:
docker push docker.io/aerogear/mobile-security-service-operator:0.1.0
The push refers to repository [docker.io/aerogear/mobile-security-service-operator]
df4a9f3f573e: Layer already exists 
4971ec651589: Layer already exists 
e3b3ca70bb46: Layer already exists 
48eeec1f62af: Layer already exists 
5bfa1c2bc41d: Layer already exists 
0.1.0: digest: sha256:47533921049156da9f39a03c652189fc3582457558cd52d6dfdc6eddaf988699 size: 1363
```

### Check quay.io hub 

> **TODO**

* See that the above tags are created in https://quay.io/repository/aerogear/mobile-security-service-operator?tab=info    

### Check the operator will be installed and still working with the new image created on quay.io.  

> **TODO**
 
* Run the operator locally 

### Verify changes in the README
* Check the Make commands
* Check the build/publish topic which was updated to reflect these changes

### Checking CI calls and actions:
* The test was done in the repo: ?
* Check the CI result in: ?

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

 
