### PR TITLE
fix: update operator.yaml to pull images from quay.io

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: mobile-security-service-operator
           # Replace this with the built image name
-          image: aerogear/mobile-security-service-operator:0.1.0
+          image: quay.io/aerogear/mobile-security-service-operator:master
           command:
           - mobile-security-service-operator
           imagePullPolicy: Always


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9130

## What
Pull the images from quay.io instead of dockerhub

## Why
Image storage moved to quay.io registry

## How
update image value in [operator.yaml](https://github.com/aerogear/mobile-security-service-operator/blob/master/deploy/operator.yaml#L20)

## Verification Steps
Install operator as per README and confirm in the openshift console that the image used is the quay.io image, and that there are no issues installing the operator related to being able to pull the image.

## Checklist:

- [ x ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

This is being changed to point to the master image for now as we don't have any released versions of the operator. After there are released versions of the operator this value should be updated to point to the image with the `latest` tag instead. 
