### PR TITLE
fix(CI): fixes operator-sdk binary used by CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run:
           name: Install operator-sdk to build image
-          command: curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.7.0/operator-sdk-v0.5.0-x86_64-linux-gnu && chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin/
+          command: curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.7.0/operator-sdk-v0.7.0-x86_64-linux-gnu && chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin/
       - run: make setup
       # circle ci key required for docker builds
       - setup_remote_docker
@@ -51,7 +51,7 @@ jobs:
           command: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run:
           name: Install operator-sdk to build image
-          command: curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.6.0/operator-sdk-v0.6.0-x86_64-linux-gnu && chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin/
+          command: curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.7.0/operator-sdk-v0.7.0-x86_64-linux-gnu && chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin/
       - run: make setup
       # circle ci key required for docker builds
       - setup_remote_docker


### PR DESCRIPTION
## Motivation
correct binary link

## What
fix breaking change introduced & update operator-sdk version used for releases

## Why
Fix link to binary & update release builds to use same operator-sdk version as master builds

## How
update circle ci config

## Verification Steps
Check master builds from CI work again

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes 
