### PR TITLE
fix(image): updates base image used for image builds (AEROGEAR-9143)

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:7.6
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/mobile-security-service-operator \
     USER_UID=1001 \


### PR DESCRIPTION
## Motivation
Security vulnerabilities in base image used for operator image builds ([AEROGEAR-9143](https://issues.jboss.org/browse/AEROGEAR-9143))

## What
Update base image

## Why
Address security vulnerabilites (1 high, 1 medium)

## How
Update base image to one that is to be introduced in the next operator-sdk release.

## Verification Steps
Build and push image manually to quay.io & check that there are no security vulnerabilities detected by security check.

Note: I have already done this and the image tagged `master` [here](https://quay.io/repository/damienomurchu/mobile-security-service-operator?tab=tags) has been built with the latest suggested base image - note all security checks pass. (The other image tagged `6802273` was built from the commit #6802273 from master on `mobile-security-service-operator` repo and has the two mentioned security vulnerabilies which can be seen).

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes 
