### PR TITLE
fix(db) : Allow the DB works when the App Service is not deployed

### DIFF
--- a/pkg/controller/mobilesecurityservicedb/controller.go
+++ b/pkg/controller/mobilesecurityservicedb/controller.go
@@ -149,13 +149,11 @@ func (r *ReconcileMobileSecurityServiceDB) Reconcile(request reconcile.Request) 
 	if err != nil {
 		// To give time for the mobile security service be created
 		time.Sleep(30 * time.Second)
-
+		// It will fetch the service instance for the DB type be able to get the configMap config created by it, however,
+		// if the Instance cannot be found and/or its configMap was not created than the default values specified in its CR will be used
 		reqLogger.Info("Checking for service instance ...")
 		serviceInstance := &mobilesecurityservicev1alpha1.MobileSecurityService{}
-		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: utils.SERVICE_INSTANCE_NAME, Namespace: utils.SERVICE_INSTANCE_NAMESPACE }, serviceInstance); err != nil {
-			return reconcile.Result{}, err
-		}
-
+		r.client.Get(context.TODO(), types.NamespacedName{Name: utils.SERVICE_INSTANCE_NAME, Namespace: utils.SERVICE_INSTANCE_NAMESPACE }, serviceInstance)
 		return r.create(instance, serviceInstance, DEEPLOYMENT, reqLogger, err)
 	}
 


### PR DESCRIPTION
## What
Fix to allow the DB works when the App Service is not deployed
## Why
The DB should still be working independently of the app 

## Verification Steps
 
1. Setup your local env to work with this PR and the image: `docker.io/cmacedo/mobile-security-service-operator:fix-db`
2. Run the command to install the oper and then just the db `make create-oper create-db-only`

<img width="1592" alt="Screenshot 2019-05-06 at 18 32 57" src="https://user-images.githubusercontent.com/7708031/57243336-cd32ab80-702d-11e9-8390-5fd59a4bff09.png">

3. Check that the database contained was created and working
4. Now run the command `make delete-all`
5. Run the command to install all `make create-all`
6. Check that all is working well  and that the ENV VAR values of the DB came from the configMap created by the APP

<img width="1598" alt="Screenshot 2019-05-06 at 18 35 33" src="https://user-images.githubusercontent.com/7708031/57243340-d1f75f80-702d-11e9-9e1f-4adbf0c4b4db.png">

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [X] Finished task
- [] TODO

## Additional Notes

