### PR TITLE
feat(route): Add path for the route

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -142,6 +142,13 @@ NOTE:
 * All values used in the default configuration came from the config-map which is managed and created by the Operator. This config map will be created in the Operator namespace and its name is defined by the attribute `configMapName` in the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService CR].
 * If the name of this ConfigMap be not specified then the name of the Mobile Security Service instance will be used instead of.
 
+
+=== Route Name and Path
+
+Into the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService CR] you are able to define the route name and its path.
+
+NOTE: This values are optionals and if they are not be defined the route name will be the names of the instance of MobileSecurityService CRD and the route will be created without a path which will make OCP generate the URL to expose the service automatically by its API.
+
 === Role for no-privilege users are able to create the Mobile Security Service App, Database and/or Bind and Unbind their apps
 
 By executing the following commands you will create roles in the cluster which will allow the <user> create the Mobile Security Service Application and Database in their namespaces. In this would not be required be the system:admin. However, the Mobile Security Service Operator is cluster scoped and will still only accessible for the `system admin users.

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
@@ -31,3 +31,4 @@ spec:
   #    The DB will looking for this ConfigMap to get the Env Values variables
   configMapName: "mobile-security-service-config"
   routeName: "service"
+  routePath: "mobile-security-service"

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservice_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservice_types.go
@@ -39,6 +39,8 @@ type MobileSecurityServiceSpec struct {
 	//CR optional configuration values
 	ConfigMapName                 string `json:"configMapName,omitempty"`
 	RouteName                     string `json:"routeName,omitempty"`
+	RoutePath                     string `json:"routePath,omitempty"`
+
 
 }
 

--- a/pkg/controller/mobilesecurityservice/helpers.go
+++ b/pkg/controller/mobilesecurityservice/helpers.go
@@ -55,3 +55,4 @@ func hasMandatorySpecs(serviceInstance *mobilesecurityservicev1alpha1.MobileSecu
 
 	return true
 }
+

--- a/pkg/controller/mobilesecurityservice/route.go
+++ b/pkg/controller/mobilesecurityservice/route.go
@@ -11,6 +11,8 @@ import (
 //buildRoute returns the route resource
 func (r *ReconcileMobileSecurityService) buildRoute(m *mobilesecurityservicev1alpha1.MobileSecurityService) *routev1.Route {
 	ls := getAppLabels(m.Name)
+
+
 	route := &routev1.Route{
 		TypeMeta: v1.TypeMeta{
 			APIVersion: "v1",
@@ -27,6 +29,10 @@ func (r *ReconcileMobileSecurityService) buildRoute(m *mobilesecurityservicev1al
 				Name: m.Name ,
 			},
 		},
+	}
+
+	if len(m.Spec.RoutePath) > 0 {
+		route.Spec.Path = m.Spec.RoutePath
 	}
 
 	// Set MobileSecurityService instance as the owner and controller


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9141

## What
* Add path for the route impl
* update the readme

## Why
* Allow users define a more friendly URL to expose the service

## Verification Steps
1. Config your local env with this PR and the image `docker.io/cmacedo/mobile-security-service-operator:AEROGEAR-9141`
2. Install all by `make create-all`
3. Check if the route was created and if it is working 
4. Create an app by `oc new-project test and make create-app`
5. Check if the app was created in the REST Service API

NOTE: You can change the routePath in the MSS CR and check that it will be the new URL when the operator installs it. 

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [] Finished task
- [X] TODO

## Additional Notes

