### PR TITLE
fix(): Remove hardcoded namespace for the operator (AEROGEAR-9152)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ IMAGE_DEV_TAG=$(IMAGE_REGISTRY)/$(REGISTRY_ORG)/$(REGISTRY_REPO):$(TAG)-$(DEV)
 IMAGE_LATEST_TAG=$(IMAGE_REGISTRY)/$(REGISTRY_ORG)/$(REGISTRY_REPO):latest
 IMAGE_MASTER_TAG=$(IMAGE_REGISTRY)/$(REGISTRY_ORG)/$(REGISTRY_REPO):master
 IMAGE_RELEASE_TAG=$(IMAGE_REGISTRY)/$(REGISTRY_ORG)/$(REGISTRY_REPO):$(CIRCLE_TAG)
-NAMESPACE=mobile-security-service-operator
+NAMESPACE=mobile-security-service
 APP_NAMESPACE=mobile-security-service-apps
 
 # This follows the output format for goreleaser
@@ -89,12 +89,12 @@ delete-all:
 	- kubectl delete -f deploy/operator.yaml
 	- kubectl delete -f deploy/role.yaml
 	- kubectl delete -f deploy/role_binding.yaml
-	- kubectl delete namespace mobile-security-service-operator
+	- kubectl delete namespace ${NAMESPACE}
 
 .PHONY: create-oper
 create-oper:
 	@echo Create Mobile Security Service Operator:
-	- kubectl create namespace mobile-security-service-operator
+	- oc new-project ${NAMESPACE}
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityserviceapp_crd.yaml
@@ -200,7 +200,7 @@ debug-setup:
 	@echo Exporting WATCH_NAMESPACE=default:
 	- export WATCH_NAMESPACE=default
 	@echo Create Namespace:
-	- kubectl create namespace mobile-security-service-operator
+	- oc new-project ${NAMESPACE}
 	@echo Installing the CRD:
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml

--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ ifdef::env-github[]
 :caution-caption: :fire:
 :warning-caption: :warning:
 :table-caption!:
-:namespace: mobile-security-service-operator
+:namespace: mobile-security-service
 endif::[]
 
 :toc:

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: mobile-security-service-operator
-  namespace: mobile-security-service-operator
 rules:
 - apiGroups:
   - "*"

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -2,12 +2,11 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: mobile-security-service-operator
-  namespace: mobile-security-service-operator
 subjects:
 - kind: ServiceAccount
   name: mobile-security-service-operator
   # Replace this with the namespace the operator is deployed in.
-  namespace: mobile-security-service-operator
+  namespace: mobile-security-service
 roleRef:
   kind: ClusterRole
   name: mobile-security-service-operator

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: mobile-security-service.aerogear.com/v1alpha1
 kind: MobileSecurityService
 metadata:
   name: mobile-security-service
-  namespace: mobile-security-service-operator
+  namespace: mobile-security-service
 spec:
   size: 1
   # It is the image:tag used to create the mobile security service deployment

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
@@ -2,7 +2,7 @@ apiVersion: mobile-security-service.aerogear.com/v1alpha1
 kind: MobileSecurityServiceDB
 metadata:
   name: mobile-security-service-db
-  namespace: mobile-security-service-operator
+  namespace: mobile-security-service
 spec:
   size: 1
   # The imaged used in this project is from Red Hat. See more in https://docs.okd.io/latest/using_images/db_images/postgresql.html

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mobile-security-service-operator
-  namespace: mobile-security-service-operator
 spec:
   replicas: 1
   selector:

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: mobile-security-service-operator
-  namespace: mobile-security-service-operator
   annotations:
     # The following annotation is required for the OAuth configuration
     serviceaccounts.openshift.io/oauth-redirectreference.mobile-security-service-app: >-

--- a/pkg/controller/mobilesecurityserviceapp/controller.go
+++ b/pkg/controller/mobilesecurityserviceapp/controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -134,7 +135,8 @@ func (r *ReconcileMobileSecurityServiceApp) Reconcile(request reconcile.Request)
 
 	reqLogger.Info("Checking for service instance ...")
 	serviceInstance := &mobilesecurityservicev1alpha1.MobileSecurityService{}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: utils.SERVICE_INSTANCE_NAME, Namespace: utils.SERVICE_INSTANCE_NAMESPACE}, serviceInstance); err != nil {
+	operatorNamespace, _ := k8sutil.GetOperatorNamespace()
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: utils.SERVICE_INSTANCE_NAME, Namespace: operatorNamespace}, serviceInstance); err != nil {
 		// Return and don't create
 		reqLogger.Info("Mobile Security Service instance resource not found. Ignoring since object must be deleted")
 		return reconcile.Result{}, nil
@@ -147,7 +149,7 @@ func (r *ReconcileMobileSecurityServiceApp) Reconcile(request reconcile.Request)
 
 	reqLogger.Info("Checking if the route already exists ...")
 	route := &routev1.Route{}
-	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: utils.GetRouteName(serviceInstance), Namespace: utils.SERVICE_INSTANCE_NAMESPACE}, route); err != nil {
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: utils.GetRouteName(serviceInstance), Namespace: operatorNamespace}, route); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/mobilesecurityservicedb/controller.go
+++ b/pkg/controller/mobilesecurityservicedb/controller.go
@@ -146,13 +146,13 @@ func (r *ReconcileMobileSecurityServiceDB) Reconcile(request reconcile.Request) 
 		return fetch(r, reqLogger, err)
 	}
 
+	operatorNamespace, _ := k8sutil.GetOperatorNamespace()
 	// FIXME: Check if is a valid namespace
 	// We should not checked if the namespace is valid or not. It is an workaround since currently is not possible watch/cache a List of Namespaces
 	// The impl to allow do it is done and merged in the master branch of the lib but not released in an stable version. It should be removed when this feature be impl.
 	// See the PR which we are working on to update the deps and have this feature: https://github.com/operator-framework/operator-sdk/pull/1388
 	if isValidNamespace, err := utils.IsValidOperatorNamespace(request.Namespace, instance.Spec.SkipNamespaceValidation); err != nil || isValidNamespace == false {
 		// Stop reconcile
-		operatorNamespace, _ := k8sutil.GetOperatorNamespace()
 		reqLogger.Error(err, "Unable to reconcile Mobile Security Service Database", "Request.Namespace", request.Namespace, "isValidNamespace", isValidNamespace, "Operator.Namespace", operatorNamespace)
 		return reconcile.Result{}, nil
 	}
@@ -170,7 +170,7 @@ func (r *ReconcileMobileSecurityServiceDB) Reconcile(request reconcile.Request) 
 		// if the Instance cannot be found and/or its configMap was not created than the default values specified in its CR will be used
 		reqLogger.Info("Checking for service instance ...")
 		serviceInstance := &mobilesecurityservicev1alpha1.MobileSecurityService{}
-		r.client.Get(context.TODO(), types.NamespacedName{Name: utils.SERVICE_INSTANCE_NAME, Namespace: utils.SERVICE_INSTANCE_NAMESPACE}, serviceInstance)
+		r.client.Get(context.TODO(), types.NamespacedName{Name: utils.SERVICE_INSTANCE_NAME, Namespace: operatorNamespace}, serviceInstance)
 		return r.create(instance, serviceInstance, DEEPLOYMENT, reqLogger, err)
 	}
 

--- a/pkg/controller/mobilesecurityservicedb/helpers.go
+++ b/pkg/controller/mobilesecurityservicedb/helpers.go
@@ -2,8 +2,10 @@ package mobilesecurityservicedb
 
 import (
 	"context"
+
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
 	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -42,7 +44,8 @@ func (r *ReconcileMobileSecurityServiceDB) hasAppConfigMap(m *mobilesecurityserv
 
 	//Looking for the configMap created by the service instance
 	configMap := &corev1.ConfigMap{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: utils.GetConfigMapName(serviceInstance), Namespace: utils.SERVICE_INSTANCE_NAMESPACE}, configMap)
+	operatorNamespace, _ := k8sutil.GetOperatorNamespace()
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: utils.GetConfigMapName(serviceInstance), Namespace: operatorNamespace}, configMap)
 	if err != nil {
 		return false
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -15,11 +15,10 @@ import (
 // The namespaces should be informed split by ";".
 const APP_NAMESPACE_ENV_VAR = "APP_NAMESPACES"
 const SERVICE_INSTANCE_NAME = "mobile-security-service"
-const SERVICE_INSTANCE_NAMESPACE = "mobile-security-service-operator"
 
 var log = logf.Log.WithName("mobile-security-service-operator.utils")
 
-// GetRouteName returns an string name with the name of the router
+//GetRouteName returns an string name with the name of the router
 func GetRouteName(m *mobilesecurityservicev1alpha1.MobileSecurityService) string {
 	if len(m.Spec.RouteName) > 0 {
 		return m.Spec.RouteName


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9152

## What
Where possible, removing hardcoded references to the operator namespace

## Why
Would be unable to deploy the operator in any namespace other than the one hardcoded

## How
Removed where possible from the code

## Verification Steps
1. Config your local env with this PR and the image `docker.io/aerogear/mobile-security-service-operator:0.1.0-AG-9152`
2. Install all by `make create-all`
3. Check the operator is created in the mobile-security-service namespace
5. Check the service and db are provisioned successfully

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 
