### PR TITLE
fix(oauth): add seperate service account for oauth proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,28 +155,28 @@ delete-db-only:
 
 .PHONY: build-dev
 build-dev:
-	@echo Building operator with the tag $(IMAGE_DEV_TAG):
+	@echo Building operator with the tag: $(IMAGE_DEV_TAG)
 	operator-sdk build $(IMAGE_DEV_TAG)
 
 .PHONY: build-master
 build-master:
-	@echo Building operator with the tag $(IMAGE_MASTER_TAG):
+	@echo Building operator with the tag: $(IMAGE_MASTER_TAG)
 	operator-sdk build $(IMAGE_MASTER_TAG)
 
 .PHONY: build-release
 build-release:
-	@echo Building operator with the tag $(IMAGE_RELEASE_TAG):
+	@echo Building operator with the tag: $(IMAGE_RELEASE_TAG)
 	operator-sdk build $(IMAGE_RELEASE_TAG)
 
 .PHONY: build-latest
 build-latest:
-	@echo Building operator with the tag $(IMAGE_LATEST_TAG):
+	@echo Building operator with the tag: $(IMAGE_LATEST_TAG)
 	operator-sdk build $(IMAGE_LATEST_TAG)
 	
 .PHONY: push-dev
 push-dev:
 	@echo Pushing operator with tag $(IMAGE_DEV_TAG) to $(IMAGE_REGISTRY)
-	@docker login quay.io
+	@docker login $(IMAGE_REGISTRY)
 	docker push $(IMAGE_DEV_TAG)
 
 .PHONY: push-master

--- a/README.adoc
+++ b/README.adoc
@@ -146,8 +146,6 @@ $ make delete-all
 
 An Oauth Proxy container and the required configuration will be setup by default by the operator to provide authentication to the Mobile Security Service.
 
-NOTE: The route name which is specified in link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService CR] is also referenced in the link:./deploy/service_account.yaml[Service Account]. The Route Name specified in the Service Account needs to match the route name provided by the CR, otherwise authentication and routing will not work correctly.
-
 === Environment Variables and ConfigMap
 
 Environment Variables are used to configure the https://github.com/aerogear/mobile-security-service[Mobile Security Service] Application and Database. For further information on configuration see the https://github.com/aerogear/mobile-security-service#setup-and-configurations[Setup and Configuration] section.

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,7 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: mobile-security-service-operator
-  annotations:
-    # The following annotation is required for the OAuth configuration
-    serviceaccounts.openshift.io/oauth-redirectreference.mobile-security-service-app: >-
-      {"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"route"}}

--- a/pkg/controller/mobilesecurityservice/controller_test.go
+++ b/pkg/controller/mobilesecurityservice/controller_test.go
@@ -108,7 +108,7 @@ func TestReconcileMobileSecurityService_create(t *testing.T) {
 			},
 			args: args{
 				instance: &mssInstance,
-				kind:     DEEPLOYMENT,
+				kind:     DEPLOYMENT,
 			},
 			want:    reconcile.Result{Requeue: true},
 			wantErr: false,
@@ -178,7 +178,7 @@ func TestReconcileMobileSecurityService_buildFactory(t *testing.T) {
 			want: reflect.TypeOf(&v1beta1.Deployment{}),
 			args: args{
 				instance: &mssInstance,
-				kind:     DEEPLOYMENT,
+				kind:     DEPLOYMENT,
 			},
 		},
 		{
@@ -223,6 +223,17 @@ func TestReconcileMobileSecurityService_buildFactory(t *testing.T) {
 			args: args{
 				instance: &mssInstance,
 				kind:     ROUTE,
+			},
+		},
+		{
+			name: "should create the Service Account",
+			fields: fields{
+				scheme: scheme.Scheme,
+			},
+			want: reflect.TypeOf(&corev1.ServiceAccount{}),
+			args: args{
+				instance: &mssInstance,
+				kind:     SERVICEACCOUNT,
 			},
 		},
 		{
@@ -358,7 +369,16 @@ func TestReconcileMobileSecurityService_Reconcile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
+	serviceAccount := &corev1.ServiceAccount{}
+	err = r.client.Get(context.TODO(), req.NamespacedName, serviceAccount)
+	if err != nil {
+		t.Fatalf("get service account: (%v)", err)
+	}
 
+	res, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
 }
 
 func TestReconcileMobileSecurityService_Reconcile_InvalidSpec(t *testing.T) {

--- a/pkg/controller/mobilesecurityservice/deployments.go
+++ b/pkg/controller/mobilesecurityservice/deployments.go
@@ -34,7 +34,7 @@ func (r *ReconcileMobileSecurityService) buildDeployment(m *mobilesecurityservic
 					Labels: ls,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: "mobile-security-service-operator",
+					ServiceAccountName: m.Name,
 					Containers:         getDeploymentContainers(m),
 				},
 			},

--- a/pkg/controller/mobilesecurityservice/fetches.go
+++ b/pkg/controller/mobilesecurityservice/fetches.go
@@ -30,7 +30,15 @@ func (r *ReconcileMobileSecurityService) fetchRoute(reqLogger logr.Logger, insta
 	return route, err
 }
 
-//fetchServerService returns the application service resource created for this instance
+//fetchServiceAccount returns the ServiceAccount resource created for this instance
+func (r *ReconcileMobileSecurityService) fetchServiceAccount(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService) (*corev1.ServiceAccount, error) {
+	reqLogger.Info("Checking if the serviceaccount already exists")
+	serviceAccount := &corev1.ServiceAccount{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, serviceAccount)
+	return serviceAccount, err
+}
+
+//fetchService returns the service resource created for this instance
 func (r *ReconcileMobileSecurityService) fetchService(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService, name string) (*corev1.Service, error) {
 	reqLogger.Info("Checking if the service already exists")
 	service := &corev1.Service{}

--- a/pkg/controller/mobilesecurityservice/helpers.go
+++ b/pkg/controller/mobilesecurityservice/helpers.go
@@ -1,6 +1,8 @@
 package mobilesecurityservice
 
 import (
+	"fmt"
+
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
 	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
 	"github.com/go-logr/logr"
@@ -52,7 +54,7 @@ func getOAuthArgsMap(m *mobilesecurityservicev1alpha1.MobileSecurityService) []s
 		"--http-address=0.0.0.0:4180",
 		"--https-address=",
 		"--provider=openshift",
-		"--openshift-service-account=mobile-security-service-operator",
+		fmt.Sprintf("--openshift-service-account=%s", m.Name),
 		"--upstream=http://localhost:3000",
 		"--cookie-secure=true",
 		"--cookie-secret=SECRET",

--- a/pkg/controller/mobilesecurityservice/serviceaccount.go
+++ b/pkg/controller/mobilesecurityservice/serviceaccount.go
@@ -1,0 +1,28 @@
+package mobilesecurityservice
+
+import (
+	"fmt"
+
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Returns the Service with the properties used to setup/config the Mobile Security Service Project
+func (r *ReconcileMobileSecurityService) buildServiceAccount(m *mobilesecurityservicev1alpha1.MobileSecurityService) *corev1.ServiceAccount {
+
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        m.Name,
+			Namespace:   m.Namespace,
+			Annotations: getAnnotation(m.Spec.RouteName),
+		},
+	}
+}
+
+func getAnnotation(route string) map[string]string {
+	annotation := fmt.Sprintf("{\"kind\":\"OAuthRedirectReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Route\",\"name\":\"%s\"}}", route)
+	return map[string]string{
+		"serviceaccounts.openshift.io/oauth-redirectreference.mobile-security-service-app": annotation,
+	}
+}

--- a/pkg/controller/mobilesecurityservice/watches.go
+++ b/pkg/controller/mobilesecurityservice/watches.go
@@ -49,3 +49,13 @@ func watchRoute(c controller.Controller) error {
 	})
 	return err
 }
+
+//Watch for changes to secondary resources and requeue the owner MobileSecurityService
+//Watch ServiceAccount resources created in the project/namespace
+func watchServiceAccount(c controller.Controller) error {
+	err := c.Watch(&source.Kind{Type: &corev1.ServiceAccount{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &mobilesecurityservicev1alpha1.MobileSecurityService{},
+	})
+	return err
+}


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9154

## What
$title

## Why
More specific access control

## How
Add the additional Service Account
Reference it from the Deployment and OAuth config

## Verification Steps
1) Use image:  quay.io/laurafitzgerald/mobile-security-service-operator:0.1.0-dev-ag9154
2) Run `make create-all`
3) Verify
a) That there is a ServiceAccount called `mobile-security-service` which contains the required redirect annotation

![Screenshot 2019-05-20 at 17 09 12](https://user-images.githubusercontent.com/6498727/58036031-071daa80-7b22-11e9-8b59-6e6af02e3133.png)

b) That there is a ServiceAccount entry with the value `mobile-security-service` in the app Deployment Config
![Screenshot 2019-05-20 at 17 06 34](https://user-images.githubusercontent.com/6498727/58035946-d2115800-7b21-11e9-910b-8bcbd611cbc2.png)

c) That the new SericeAccount `mobile-security-service` is passed to the OAuth container args in the Deployment Config

![Screenshot 2019-05-20 at 17 08 27](https://user-images.githubusercontent.com/6498727/58036003-ece3cc80-7b21-11e9-9ab6-813a12969c52.png)

d) That the OAuth Service works correctly by navigating to the route and authenticating using OAuth which should allow you to view the Application.

A note on verification: There is [pr](https://github.com/aerogear/mobile-security-service-operator/pull/71) to remove SAR from the OAuth config. Please verify as part of this pr that the `developer` user is not able to log into the service. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 


 
