### PR TITLE
fix(oauth): allow users with no namespace access to log in

### DIFF
--- a/pkg/controller/mobilesecurityservice/helpers.go
+++ b/pkg/controller/mobilesecurityservice/helpers.go
@@ -1,8 +1,6 @@
 package mobilesecurityservice
 
 import (
-	"fmt"
-
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
 	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
 	"github.com/go-logr/logr"
@@ -56,7 +54,6 @@ func getOAuthArgsMap(m *mobilesecurityservicev1alpha1.MobileSecurityService) []s
 		"--provider=openshift",
 		"--openshift-service-account=mobile-security-service-operator",
 		"--upstream=http://localhost:3000",
-		fmt.Sprintf("--openshift-sar=[{\"namespace\":\"%s\",\"resource\":\"services\",\"name\":\"%s\",\"verb\":\"get\"}]", m.Namespace, m.Name),
 		"--cookie-secure=true",
 		"--cookie-secret=SECRET",
 		"--cookie-httponly=false",


### PR DESCRIPTION
## Motivation
 https://issues.jboss.org/browse/AEROGEAR-9153

## What
See JIRA

## Why
See JIRA

## How
Remove SAR config from OAuth Proxy config

## Verification Steps
1) Use image: docker.io/lfitzgerald/mobile-security-service-operator:dev-ag9153
2) Run `make create-all`
3) Verify: That the developer user can access the service

There is a previous pr where I've requested that the verify confirm that the developer user does not have access. Linked below

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 


 
