### PR TITLE
Refectory controller/reconcile code and fetch instances before updates in order to avoid issues regards the CR be already changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ IMAGE_LATEST_TAG=$(IMAGE_REGISTRY)/$(REGISTRY_ORG)/$(REGISTRY_REPO):latest
 IMAGE_MASTER_TAG=$(IMAGE_REGISTRY)/$(REGISTRY_ORG)/$(REGISTRY_REPO):master
 IMAGE_RELEASE_TAG=$(IMAGE_REGISTRY)/$(REGISTRY_ORG)/$(REGISTRY_REPO):$(CIRCLE_TAG)
 NAMESPACE=mobile-security-service
-APP_NAMESPACE=mobile-security-service-apps
+APP_NAMESPACES=mobile-security-service-apps
 
 # This follows the output format for goreleaser
 BINARY_LINUX_64 = ./dist/linux_amd64/$(BINARY)
@@ -51,8 +51,8 @@ build_linux:
 
 .PHONY: create-app-ns
 create-app-ns:
-	@echo Creating the namespace ${APP_NAMESPACE}:
-	oc new-project ${APP_NAMESPACE}
+	@echo Creating the namespace ${APP_NAMESPACES}:
+	oc new-project ${APP_NAMESPACES}
 
 .PHONY: create-app
 create-app:
@@ -67,7 +67,7 @@ delete-app:
 run-local:
 	@echo Installing the operator in a cluster and run it locally:
 	- export OPERATOR_NAME=mobile-security-service-operator
-	- export APP_NAMESPACES=${APP_NAMESPACE}
+	- export APP_NAMESPACES=${APP_NAMESPACES}
 	- make create-all
 	- operator-sdk up local --namespace=${NAMESPACE}
 

--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,12 @@ create-app:
 delete-app:
 	kubectl delete -f deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml
 
+#fixme: The exports in the make file are not working see AEROGEAR-9156. Until it be fixed, run this commands manually.
 .PHONY: run-local
 run-local:
 	@echo Installing the operator in a cluster and run it locally:
 	- export OPERATOR_NAME=mobile-security-service-operator
+	- export APP_NAMESPACES=${APP_NAMESPACE}
 	- make create-all
 	- operator-sdk up local --namespace=${NAMESPACE}
 
@@ -78,8 +80,6 @@ create-all:
 .PHONY: delete-all
 delete-all:
 	@echo Delete Mobile Security Service Operator, Service and namespace "mobile-security-service-operator":
-	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
-	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityserviceapp_crd.yaml

--- a/pkg/controller/mobilesecurityservice/fetches.go
+++ b/pkg/controller/mobilesecurityservice/fetches.go
@@ -5,26 +5,22 @@ import (
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
 	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
 	"github.com/go-logr/logr"
+	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	routev1 "github.com/openshift/api/route/v1"
 )
 
 // Request object not found, could have been deleted after reconcile request.
 // Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-func fetch(r *ReconcileMobileSecurityService, reqLogger logr.Logger, err error) (reconcile.Result, error) {
-	if errors.IsNotFound(err) {
-		// Return and don't create
-		reqLogger.Info("Mobile Security Service App resource not found. Ignoring since object must be deleted")
-		return reconcile.Result{}, nil
-	}
-	// Error reading the object - create the request.
-	reqLogger.Error(err, "Failed to get Mobile Security Service App")
-	return reconcile.Result{}, err
+func (r *ReconcileMobileSecurityService) fetchInstance( reqLogger logr.Logger, request reconcile.Request) (*mobilesecurityservicev1alpha1.MobileSecurityService, error) {
+	instance := &mobilesecurityservicev1alpha1.MobileSecurityService{}
+	//Fetch the MobileSecurityService instance
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	return instance, err
 }
+
 
 //fetchRoute returns the Route resource created for this instance
 func (r *ReconcileMobileSecurityService) fetchRoute(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService) (*routev1.Route, error) {

--- a/pkg/controller/mobilesecurityservice/status.go
+++ b/pkg/controller/mobilesecurityservice/status.go
@@ -3,30 +3,47 @@ package mobilesecurityservice
 import (
 	"context"
 	"fmt"
-	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
 	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
 	"github.com/go-logr/logr"
+	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"reflect"
-	routev1 "github.com/openshift/api/route/v1"
-
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 //updateStatus returns error when status regards the all required resources could not be updated
-func (r *ReconcileMobileSecurityService) updateStatus(reqLogger logr.Logger, configMapStatus *corev1.ConfigMap, deploymentStatus *v1beta1.Deployment, serviceStatus *corev1.Service, routeStatus *routev1.Route, instance *mobilesecurityservicev1alpha1.MobileSecurityService) error {
+func (r *ReconcileMobileSecurityService) updateStatus(reqLogger logr.Logger, configMapStatus *corev1.ConfigMap, deploymentStatus *v1beta1.Deployment, serviceStatus *corev1.Service, routeStatus *routev1.Route, request reconcile.Request) error {
 	reqLogger.Info("Updating App Status for the MobileSecurityService")
+	// Get the latest version of the CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return err
+	}
+
+	//Check if all required objects are created
 	if len(configMapStatus.UID) < 1 && len(deploymentStatus.UID) < 1 && len(serviceStatus.UID) < 1 && len(routeStatus.Name) < 1 {
 		err := fmt.Errorf("Failed to get OK Status for MobileSecurityService")
 		reqLogger.Error(err, "One of the resources are not created", "MobileSecurityService.Namespace", instance.Namespace, "MobileSecurityService.Name", instance.Name)
 		return err
 	}
 	status:= "OK"
+
+	// Update CR with the AppStatus == OK
 	if !reflect.DeepEqual(status, instance.Status.AppStatus) {
-		instance.Status.AppStatus = status
-		err := r.client.Status().Update(context.TODO(), instance)
+		// Get the latest version of the CR
+		instance, err := r.fetchInstance(reqLogger, request)
 		if err != nil {
-			reqLogger.Error(err, "Failed to update Status for the MobileSecurityService App")
+			return err
+		}
+
+		// Set the data
+		instance.Status.AppStatus = status
+
+		// Update the CR
+		err = r.client.Status().Update(context.TODO(), instance)
+		if err != nil {
+			reqLogger.Error(err, "Failed to update Project Status for the MobileSecurityService")
 			return err
 		}
 	}
@@ -34,18 +51,36 @@ func (r *ReconcileMobileSecurityService) updateStatus(reqLogger logr.Logger, con
 }
 
 //updateConfigMapStatus returns error when status regards the ConfigMap resource could not be updated
-func (r *ReconcileMobileSecurityService) updateConfigMapStatus(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService) (*corev1.ConfigMap, error) {
+func (r *ReconcileMobileSecurityService) updateConfigMapStatus(reqLogger logr.Logger, request reconcile.Request) (*corev1.ConfigMap, error) {
 	reqLogger.Info("Updating ConfigMap Status for the MobileSecurityService")
+	// Get the latest version of the CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the ConfigMap object
 	configMapStatus, err := r.fetchConfigMap(reqLogger, instance)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get ConfigMap Name for Status", "MobileSecurityService.Namespace", instance.Namespace, "MobileSecurityService.Name", instance.Name)
 		return configMapStatus, err
 	}
+
+	// Update ConfigMap Name
 	if !reflect.DeepEqual(configMapStatus.Name, instance.Status.ConfigMapName) {
-		instance.Status.ConfigMapName = configMapStatus.Name
-		err := r.client.Status().Update(context.TODO(), instance)
+		// Get the latest version of the CR
+		instance, err := r.fetchInstance(reqLogger, request)
 		if err != nil {
-			reqLogger.Error(err, "Failed to update ConfigMap Name Status for the MobileSecurityService")
+			return nil, err
+		}
+
+		// Set the data
+		instance.Status.ConfigMapName = configMapStatus.Name
+
+		// Update the CR
+		err = r.client.Status().Update(context.TODO(), instance)
+		if err != nil {
+			reqLogger.Error(err, "Failed to update ConfigMap Name and Status for the MobileSecurityService")
 			return configMapStatus, err
 		}
 	}
@@ -53,85 +88,121 @@ func (r *ReconcileMobileSecurityService) updateConfigMapStatus(reqLogger logr.Lo
 }
 
 //updateDeploymentStatus returns error when status regards the Deployment resource could not be updated
-func (r *ReconcileMobileSecurityService) updateDeploymentStatus(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService) (*v1beta1.Deployment, error) {
+func (r *ReconcileMobileSecurityService) updateDeploymentStatus(reqLogger logr.Logger, request reconcile.Request) (*v1beta1.Deployment, error) {
 	reqLogger.Info("Updating Deployment Status for the MobileSecurityService")
+	// Get the latest version of the CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the deployment object
 	deploymentStatus, err := r.fetchDeployment(reqLogger, instance)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get Deployment for Status", "MobileSecurityService.Namespace", instance.Namespace, "MobileSecurityService.Name", instance.Name)
 		return deploymentStatus, err
 	}
-	if !reflect.DeepEqual(deploymentStatus.Name, instance.Status.DeploymentName) {
+
+	// Update the Deployment Name and Status
+	if !reflect.DeepEqual(deploymentStatus.Name, instance.Status.DeploymentName) || !reflect.DeepEqual(deploymentStatus.Status, instance.Status.DeploymentStatus) {
+		// Get the latest version of the CR
+		instance, err := r.fetchInstance(reqLogger, request)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the data
 		instance.Status.DeploymentName = deploymentStatus.Name
-		err := r.client.Status().Update(context.TODO(), instance)
-		if err != nil {
-			reqLogger.Error(err, "Failed to update Deployment Name Status for the MobileSecurityService")
-			return deploymentStatus, err
-		}
-	}
-	if !reflect.DeepEqual(deploymentStatus.Status, instance.Status.DeploymentStatus) {
 		instance.Status.DeploymentStatus = deploymentStatus.Status
-		err := r.client.Status().Update(context.TODO(), instance)
+
+		// Update the CR
+		err = r.client.Status().Update(context.TODO(), instance)
 		if err != nil {
-			reqLogger.Error(err, "Failed to update Deployment Status for the MobileSecurityService")
+			reqLogger.Error(err, "Failed to update Deployment Name and Status for the MobileSecurityService")
 			return deploymentStatus, err
 		}
 	}
+
 	return deploymentStatus, nil
 }
 
 //updateServiceStatus returns error when status regards the Service resource could not be updated
-func (r *ReconcileMobileSecurityService) updateServiceStatus(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService) (*corev1.Service, error) {
+func (r *ReconcileMobileSecurityService) updateServiceStatus(reqLogger logr.Logger, request reconcile.Request) (*corev1.Service, error) {
 	reqLogger.Info("Updating Service Status for the MobileSecurityService")
+	// Get the latest version of the CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return nil, err
+	}
+	// Get the Service Object
 	serviceStatus, err := r.fetchService(reqLogger, instance)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get Service for Status", "MobileSecurityService.Namespace", instance.Namespace, "MobileSecurityService.Name", instance.Name)
 		return serviceStatus, err
 	}
-	if !reflect.DeepEqual(serviceStatus.Name, instance.Status.ServiceName) {
+
+	// Update the Service Status and Name
+	if !reflect.DeepEqual(serviceStatus.Name, instance.Status.ServiceName) || !reflect.DeepEqual(serviceStatus.Status, instance.Status.ServiceStatus) {
+		// Get the latest version of the CR
+		instance, err := r.fetchInstance(reqLogger, request)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the data
 		instance.Status.ServiceName = serviceStatus.Name
-		err := r.client.Status().Update(context.TODO(), instance)
-		if err != nil {
-			reqLogger.Error(err, "Failed to update Service Name Status for the MobileSecurityService")
-			return serviceStatus, err
-		}
-	}
-	if !reflect.DeepEqual(serviceStatus.Status, instance.Status.ServiceStatus) {
 		instance.Status.ServiceStatus = serviceStatus.Status
-		err := r.client.Status().Update(context.TODO(), instance)
+
+		// Update the CR
+		err = r.client.Status().Update(context.TODO(), instance)
 		if err != nil {
-			reqLogger.Error(err, "Failed to update Service Status for the MobileSecurityService")
+			reqLogger.Error(err, "Failed to update Service Name and Status for the MobileSecurityService")
 			return serviceStatus, err
 		}
 	}
+
 	return serviceStatus, nil
 }
 
 //updateRouteStatus returns error when status regards the route resource could not be updated
-func (r *ReconcileMobileSecurityService) updateRouteStatus(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService) (*routev1.Route, error) {
+func (r *ReconcileMobileSecurityService) updateRouteStatus(reqLogger logr.Logger, request reconcile.Request) (*routev1.Route, error) {
 	reqLogger.Info("Updating Route Status for the MobileSecurityService")
+	// Get the latest version of the CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return nil, err
+	}
+
+	//Get the route Object
 	route, err := r.fetchRoute(reqLogger, instance)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get Route for Status", "MobileSecurityService.Namespace", instance.Namespace, "MobileSecurityService.Name", instance.Name)
 		return route, err
 	}
+
+	// Update the Route Name
 	routeName := utils.GetRouteName(instance)
-	if !reflect.DeepEqual(routeName, instance.Status.RouteName) {
-		instance.Status.RouteName = routeName
-		err := r.client.Status().Update(context.TODO(), instance)
+
+	// Update the Route Status and Name
+	if !reflect.DeepEqual(routeName, instance.Status.RouteName) || !reflect.DeepEqual(route.Status, instance.Status.RouteStatus) {
+
+		// Get the latest version of the CR
+		instance, err := r.fetchInstance(reqLogger, request)
 		if err != nil {
-			reqLogger.Error(err, "Failed to update Route Name Status for the MobileSecurityService")
-			return route, err
+			return nil, err
 		}
-	}
-	if !reflect.DeepEqual(route.Status, instance.Status.RouteStatus) {
+
+		// Set the data
+		instance.Status.RouteName = routeName
 		instance.Status.RouteStatus = route.Status
-		err := r.client.Status().Update(context.TODO(), instance)
+
+		// Update the CR
+		err = r.client.Status().Update(context.TODO(), instance)
 		if err != nil {
-			reqLogger.Error(err, "Failed to update Route Status for the MobileSecurityService")
+			reqLogger.Error(err, "Failed to update Route Name and Status for the MobileSecurityService")
 			return route, err
 		}
 	}
 	return route, nil
 }
-
 

--- a/pkg/controller/mobilesecurityserviceapp/fetches.go
+++ b/pkg/controller/mobilesecurityserviceapp/fetches.go
@@ -3,27 +3,23 @@ package mobilesecurityserviceapp
 import (
 	"context"
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	"github.com/aerogear/mobile-security-service-operator/pkg/models"
 	"github.com/aerogear/mobile-security-service-operator/pkg/service"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"github.com/aerogear/mobile-security-service-operator/pkg/models"
 )
 
 // Request object not found, could have been deleted after reconcile request.
 // Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-func fetch(r *ReconcileMobileSecurityServiceApp, reqLogger logr.Logger, err error) (reconcile.Result, error) {
-	if errors.IsNotFound(err) {
-		// Return and don't create
-		reqLogger.Info("Mobile Security Service App resource not found. Ignoring since object must be deleted")
-		return reconcile.Result{}, nil
-	}
-	// Error reading the object - create the request.
-	reqLogger.Error(err, "Failed to get Mobile Security Service App")
-	return reconcile.Result{}, err
+func (r *ReconcileMobileSecurityServiceApp) fetchInstance( reqLogger logr.Logger, request reconcile.Request) (*mobilesecurityservicev1alpha1.MobileSecurityServiceApp, error) {
+	instance := &mobilesecurityservicev1alpha1.MobileSecurityServiceApp{}
+	//Fetch the MobileSecurityServiceApp instance
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	return instance, err
 }
+
 
 //fetchSDKConfigMap returns the config map resource created for this instance
 func (r *ReconcileMobileSecurityServiceApp) fetchSDKConfigMap(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp) (*corev1.ConfigMap, error) {

--- a/pkg/controller/mobilesecurityserviceapp/finalizer.go
+++ b/pkg/controller/mobilesecurityserviceapp/finalizer.go
@@ -1,14 +1,18 @@
 package mobilesecurityserviceapp
 
 import (
+	"context"
 	"fmt"
 	"github.com/aerogear/mobile-security-service-operator/pkg/service"
 	"github.com/go-logr/logr"
-	"context"
-	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 //updateFinilizer returns error when the app still not deleted in the REST Service
-func (r *ReconcileMobileSecurityServiceApp) updateFinilizer(serviceAPI string,reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp) error {
+func (r *ReconcileMobileSecurityServiceApp) updateFinilizer(serviceAPI string,reqLogger logr.Logger, request reconcile.Request) error {
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return err
+	}
 	if len(instance.GetFinalizers()) > 0 && instance.GetDeletionTimestamp() != nil {
 		reqLogger.Info("Removing Finalizer for the MobileSecurityServiceApp")
 		if app, err := fetchBindAppRestServiceByAppID(serviceAPI, instance, reqLogger);  err != nil || hasApp(app){
@@ -31,7 +35,11 @@ func (r *ReconcileMobileSecurityServiceApp) updateFinilizer(serviceAPI string,re
 }
 
 //handleFinalizer check if has the finalizer and delete the app
-func (r *ReconcileMobileSecurityServiceApp) handleFinalizer(serviceAPI string,reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp) error {
+func (r *ReconcileMobileSecurityServiceApp) handleFinalizer(serviceAPI string,reqLogger logr.Logger, request reconcile.Request) error {
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return err
+	}
 	// set up finalizers
 	if len(instance.GetFinalizers()) > 0 && instance.GetDeletionTimestamp() != nil {
 		//Check if App is delete into the REST Service

--- a/pkg/controller/mobilesecurityserviceapp/status.go
+++ b/pkg/controller/mobilesecurityserviceapp/status.go
@@ -3,23 +3,42 @@ package mobilesecurityserviceapp
 import (
 	"context"
 	"fmt"
-	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 //updateSDKConfigMapStatus returns error when status regards the ConfigMap resource could not be updated
-func (r *ReconcileMobileSecurityServiceApp) updateSDKConfigMapStatus(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp) (*corev1.ConfigMap, error) {
+func (r *ReconcileMobileSecurityServiceApp) updateSDKConfigMapStatus(reqLogger logr.Logger, request reconcile.Request) (*corev1.ConfigMap, error) {
 	reqLogger.Info("Updating SDKConfigMap Status for the MobileSecurityServiceApp")
+
+	// Get the latest version of CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return &corev1.ConfigMap{}, err
+	}
+
+	// Get SDKConfigMap object
 	SDKConfigMapStatus, err := r.fetchSDKConfigMap(reqLogger, instance)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get SDKConfigMap for Status", "MobileSecurityServiceApp.Namespace", instance.Namespace, "MobileSecurityServiceApp.Name", instance.Name)
 		return SDKConfigMapStatus, err
 	}
+
+	//Update CR Status with SDKConfigMap name
 	if !reflect.DeepEqual(SDKConfigMapStatus.Name, instance.Status.SDKConfigMapName) {
+		// Get the latest version of CR
+		instance, err := r.fetchInstance(reqLogger, request)
+		if err != nil {
+			return &corev1.ConfigMap{}, err
+		}
+
+		// Set the data
 		instance.Status.SDKConfigMapName = SDKConfigMapStatus.Name
-		err := r.client.Status().Update(context.TODO(), instance)
+
+		// Update the CR
+		err = r.client.Status().Update(context.TODO(), instance)
 		if err != nil {
 			reqLogger.Error(err, "Failed to update SDKConfigMap Status for the MobileSecurityServiceApp")
 			return SDKConfigMapStatus, err
@@ -29,22 +48,44 @@ func (r *ReconcileMobileSecurityServiceApp) updateSDKConfigMapStatus(reqLogger l
 }
 
 //updateAppStatus returns error when status regards the all required resources could not be updated
-func (r *ReconcileMobileSecurityServiceApp) updateBindStatus(serviceURL string,reqLogger logr.Logger, SDKConfigMapStatus *corev1.ConfigMap, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp) error {
+func (r *ReconcileMobileSecurityServiceApp) updateBindStatus(serviceURL string,reqLogger logr.Logger, SDKConfigMapStatus *corev1.ConfigMap, request reconcile.Request) error {
 	reqLogger.Info("Updating Bind App Status for the MobileSecurityServiceApp")
+
+	// Get the latest version of CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return err
+	}
+
+	// Get App created in the Rest Service
 	app, err := fetchBindAppRestServiceByAppID(serviceURL, instance, reqLogger)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get App for Status", "MobileSecurityServiceApp.Namespace", instance.Namespace, "MobileSecurityServiceApp.Name", instance.Name)
 		return err
 	}
+
+	// Check if the ConfigMap and the App is created in the Rest Service
 	if len(SDKConfigMapStatus.UID) < 1 && !hasApp(app) {
 		err := fmt.Errorf("Failed to get OK Status for MobileSecurityService Bind.")
 		reqLogger.Error(err, "One of the resources are not created", "MobileSecurityServiceApp.Namespace", instance.Namespace, "MobileSecurityServiceApp.Name", instance.Name)
 		return err
 	}
 	status:= "OK"
+
+	//Update Bind CR Status with OK
 	if !reflect.DeepEqual(status, instance.Status.BindStatus) {
+
+		// Get the latest version of CR
+		instance, err := r.fetchInstance(reqLogger, request)
+		if err != nil {
+			return err
+		}
+
+		// Set the data
 		instance.Status.BindStatus = status
-		err := r.client.Status().Update(context.TODO(), instance)
+
+		// Update the CR
+		err = r.client.Status().Update(context.TODO(), instance)
 		if err != nil {
 			reqLogger.Error(err, "Failed to update Status for the MobileSecurityService Bind")
 			return err
@@ -52,4 +93,3 @@ func (r *ReconcileMobileSecurityServiceApp) updateBindStatus(serviceURL string,r
 	}
 	return nil
 }
-

--- a/pkg/controller/mobilesecurityservicedb/fetches.go
+++ b/pkg/controller/mobilesecurityservicedb/fetches.go
@@ -1,27 +1,22 @@
 package mobilesecurityservicedb
 
 import (
-	"k8s.io/apimachinery/pkg/api/errors"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"context"
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
 	"github.com/go-logr/logr"
-	"k8s.io/api/extensions/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // Request object not found, could have been deleted after reconcile request.
 // Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-func fetch(r *ReconcileMobileSecurityServiceDB, reqLogger logr.Logger, err error) (reconcile.Result, error) {
-	if errors.IsNotFound(err) {
-		// Return and don't create
-		reqLogger.Info("Mobile Security Service DB resource not found. Ignoring since object must be deleted")
-		return reconcile.Result{}, nil
-	}
-	// Error reading the object - create the request.
-	reqLogger.Error(err, "Failed to get Mobile Security Service DB")
-	return reconcile.Result{}, err
+func (r *ReconcileMobileSecurityServiceDB) fetchInstance( reqLogger logr.Logger, request reconcile.Request) (*mobilesecurityservicev1alpha1.MobileSecurityServiceDB, error) {
+	instance := &mobilesecurityservicev1alpha1.MobileSecurityServiceDB{}
+	//Fetch the MobileSecurityServiceDB instance
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	return instance, err
 }
 
 //fetchDBService returns the service resource created for this instance

--- a/pkg/controller/mobilesecurityservicedb/status.go
+++ b/pkg/controller/mobilesecurityservicedb/status.go
@@ -3,27 +3,48 @@ package mobilesecurityservicedb
 import (
 	"context"
 	"fmt"
-	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 //updateAppStatus returns error when status regards the all required resources could not be updated
-func (r *ReconcileMobileSecurityServiceDB) updateDBStatus(reqLogger logr.Logger, deploymentStatus *v1beta1.Deployment, serviceStatus *corev1.Service, pvcStatus *corev1.PersistentVolumeClaim, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceDB) error {
+func (r *ReconcileMobileSecurityServiceDB) updateDBStatus(reqLogger logr.Logger, deploymentStatus *v1beta1.Deployment, serviceStatus *corev1.Service, pvcStatus *corev1.PersistentVolumeClaim, request reconcile.Request) error {
 	reqLogger.Info("Updating App Status for the MobileSecurityServiceDB")
+
+	//Get the latest version of the CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return err
+	}
+
+	// Check if ALL required objects are created
 	if len(deploymentStatus.Name) < 1 && len(serviceStatus.Name) < 1 && len(pvcStatus.Name) < 1 {
 		err := fmt.Errorf("Failed to get OK Status for MobileSecurityService Database")
 		reqLogger.Error(err, "One of the resources are not created", "MobileSecurityServiceDB.Namespace", instance.Namespace, "MobileSecurityServiceDB.Name", instance.Name)
 		return err
 	}
 	status:= "OK"
+
+
+	// Update Database Status == OK
 	if !reflect.DeepEqual(status, instance.Status.DatabaseStatus) {
+
+		//Get the latest version of the CR
+		instance, err = r.fetchInstance(reqLogger, request)
+		if err != nil {
+			return err
+		}
+
+		// Set the data
 		instance.Status.DatabaseStatus = status
+
+		// Update the CR
 		err := r.client.Status().Update(context.TODO(), instance)
 		if err != nil {
-			reqLogger.Error(err, "Failed to update Status for the MobileSecurityService Database")
+			reqLogger.Error(err, "Failed to update Deployment Status for the MobileSecurityService Database")
 			return err
 		}
 	}
@@ -31,69 +52,107 @@ func (r *ReconcileMobileSecurityServiceDB) updateDBStatus(reqLogger logr.Logger,
 }
 
 //updateDeploymentStatus returns error when status regards the Deployment resource could not be updated
-func (r *ReconcileMobileSecurityServiceDB) updateDeploymentStatus(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceDB) (*v1beta1.Deployment, error) {
+func (r *ReconcileMobileSecurityServiceDB) updateDeploymentStatus(reqLogger logr.Logger,request reconcile.Request) (*v1beta1.Deployment, error) {
 	reqLogger.Info("Updating Deployment Status for the MobileSecurityServiceDB")
+	// Get the latest version of the instance CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return nil, err
+	}
+	// Get the Deployment Object
 	deploymentStatus, err := r.fetchDBDeployment(reqLogger, instance)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get Deployment for Status", "MobileSecurityServiceDB.Namespace", instance.Namespace, "MobileSecurityServiceDB.Name", instance.Name)
 		return deploymentStatus, err
 	}
-	if !reflect.DeepEqual(deploymentStatus.Name, instance.Status.DeploymentName) {
+	// Update the Deployment Name and Status
+	if !reflect.DeepEqual(deploymentStatus.Name, instance.Status.DeploymentName) || !reflect.DeepEqual(deploymentStatus.Status, instance.Status.DeploymentStatus){
+		// Get the latest version of the instance CR
+		instance, err = r.fetchInstance(reqLogger, request)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the data
 		instance.Status.DeploymentName = deploymentStatus.Name
-		err := r.client.Status().Update(context.TODO(), instance)
-		if err != nil {
-			reqLogger.Error(err, "Failed to update Deployment Name Status for the MobileSecurityServiceDB")
-			return deploymentStatus, err
-		}
-	}
-	if !reflect.DeepEqual(deploymentStatus.Status, instance.Status.DeploymentStatus) {
 		instance.Status.DeploymentStatus = deploymentStatus.Status
+
+		// Update the CR
 		err := r.client.Status().Update(context.TODO(), instance)
 		if err != nil {
-			reqLogger.Error(err, "Failed to update Deployment Status for the MobileSecurityServiceDB")
+			reqLogger.Error(err, "Failed to update Deployment Name and Status for the MobileSecurityServiceDB")
 			return deploymentStatus, err
 		}
 	}
+
 	return deploymentStatus, nil
 }
 
 //updateServiceStatus returns error when status regards the Service resource could not be updated
-func (r *ReconcileMobileSecurityServiceDB) updateServiceStatus(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceDB) (*corev1.Service, error) {
+func (r *ReconcileMobileSecurityServiceDB) updateServiceStatus(reqLogger logr.Logger, request reconcile.Request) (*corev1.Service, error) {
 	reqLogger.Info("Updating Service Status for the MobileSecurityServiceDB")
+	// Get the latest version of the instance CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return nil, err
+	}
+	// Get the Service Object
 	serviceStatus, err := r.fetchDBService(reqLogger, instance)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get Service for Status", "MobileSecurityServiceDB.Namespace", instance.Namespace, "MobileSecurityServiceDB.Name", instance.Name)
 		return serviceStatus, err
 	}
-	if !reflect.DeepEqual(serviceStatus.Name, instance.Status.ServiceName) {
+
+	// Update the Service Name and Status
+	if !reflect.DeepEqual(serviceStatus.Name, instance.Status.ServiceName) || !reflect.DeepEqual(serviceStatus.Status, instance.Status.ServiceStatus)  {
+		// Get the latest version of the instance CR
+		instance, err = r.fetchInstance(reqLogger, request)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the data
 		instance.Status.ServiceName = serviceStatus.Name
+
+		// Update the CR
 		err := r.client.Status().Update(context.TODO(), instance)
 		if err != nil {
-			reqLogger.Error(err, "Failed to update Service Name Status for the MobileSecurityServiceDB")
+			reqLogger.Error(err, "Failed to update Service Name and Status for the MobileSecurityServiceDB")
 			return serviceStatus, err
 		}
 	}
-	if !reflect.DeepEqual(serviceStatus.Status, instance.Status.ServiceStatus) {
-		instance.Status.ServiceStatus = serviceStatus.Status
-		err := r.client.Status().Update(context.TODO(), instance)
-		if err != nil {
-			reqLogger.Error(err, "Failed to update Service Status for the MobileSecurityServiceDB")
-			return serviceStatus, err
-		}
-	}
+
 	return serviceStatus, nil
 }
 
 //updatePvcStatus returns error when status regards the PersistentVolumeClaim resource could not be updated
-func (r *ReconcileMobileSecurityServiceDB) updatePvcStatus(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceDB) (*corev1.PersistentVolumeClaim, error) {
+func (r *ReconcileMobileSecurityServiceDB) updatePvcStatus(reqLogger logr.Logger, request reconcile.Request) (*corev1.PersistentVolumeClaim, error) {
 	reqLogger.Info("Updating PersistentVolumeClaim Status for the MobileSecurityServiceDB")
+	// Get the latest version of the CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get PVC Object
 	pvcStatus, err := r.fetchDBPersistentVolumeClaim(reqLogger, instance)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get PersistentVolumeClaim for Status", "MobileSecurityServiceDB.Namespace", instance.Namespace, "MobileSecurityServiceDB.Name", instance.Name)
 		return pvcStatus, err
 	}
+
+	// Update CR with PVC name
 	if !reflect.DeepEqual(pvcStatus.Name, instance.Status.PersistentVolumeClaimName) {
+		// Get the latest version of the instance CR
+		instance, err = r.fetchInstance(reqLogger, request)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the data
 		instance.Status.PersistentVolumeClaimName = pvcStatus.Name
+
+		// Update the CR
 		err := r.client.Status().Update(context.TODO(), instance)
 		if err != nil {
 			reqLogger.Error(err, "Failed to update PersistentVolumeClaim Status for the MobileSecurityServiceDB")
@@ -102,4 +161,3 @@ func (r *ReconcileMobileSecurityServiceDB) updatePvcStatus(reqLogger logr.Logger
 	}
 	return pvcStatus, nil
 }
-


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9169

## What
- Add export app namespace and remove unnecessary commands
- Refectory controller/reconcile code and fetch instances before updates in order to avoid issues regards the CR be already changed

## Why

**Explanation**
Logs as `Failed to update Status for the Component .... the object has been modified; please apply your changes to the latest version and try again"}` are faced because when the client will update the CR it was already changed. It is like when we go by the OCP UI and try to edit the YAML file of one CR which was changed between the time that the page was rendered and our click on the save button. 
- Try to avoid the above log issues
- Make easier troubleshooting and follow the logs.
- Make easier to keep the project maintained and allow it to be improved. 

## How
- Fetch the latest version of the CR before the updates
- Add comments to explain what is doing in each part
- Improve/Refactory the code 

## Verification Steps
- Install the operator with this PR and image `docker.io/cmacedo/mobile-security-service-operator:AEROGEAR-9169`
- Run `make create-all`
- Check that all was created with success
- In Resources >> other resources: Check that the status was update

<img width="1352" alt="Screenshot 2019-05-12 at 20 27 54" src="https://user-images.githubusercontent.com/7708031/57586903-83960500-74f4-11e9-9674-b6d7cf662159.png">

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
