### PR TITLE
fix(oauth): allow server access to the operator

### DIFF
--- a/pkg/controller/mobilesecurityservice/fetches.go
+++ b/pkg/controller/mobilesecurityservice/fetches.go
@@ -30,19 +30,11 @@ func (r *ReconcileMobileSecurityService) fetchRoute(reqLogger logr.Logger, insta
 	return route, err
 }
 
-//fetchService returns the service resource created for this instance
-func (r *ReconcileMobileSecurityService) fetchService(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService) (*corev1.Service, error) {
+//fetchServerService returns the application service resource created for this instance
+func (r *ReconcileMobileSecurityService) fetchService(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService, name string) (*corev1.Service, error) {
 	reqLogger.Info("Checking if the service already exists")
 	service := &corev1.Service{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, service)
-	return service, err
-}
-
-//fetchServerService returns the service resource created for this instance
-func (r *ReconcileMobileSecurityService) fetchServerService(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService) (*corev1.Service, error) {
-	reqLogger.Info("Checking if the service already exists")
-	service := &corev1.Service{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: utils.SERVER_SERVICE_INSTANCE_NAME, Namespace: instance.Namespace}, service)
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: instance.Namespace}, service)
 	return service, err
 }
 

--- a/pkg/controller/mobilesecurityservice/fetches.go
+++ b/pkg/controller/mobilesecurityservice/fetches.go
@@ -2,6 +2,7 @@ package mobilesecurityservice
 
 import (
 	"context"
+
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
 	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
 	"github.com/go-logr/logr"
@@ -14,13 +15,12 @@ import (
 
 // Request object not found, could have been deleted after reconcile request.
 // Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-func (r *ReconcileMobileSecurityService) fetchInstance( reqLogger logr.Logger, request reconcile.Request) (*mobilesecurityservicev1alpha1.MobileSecurityService, error) {
+func (r *ReconcileMobileSecurityService) fetchInstance(reqLogger logr.Logger, request reconcile.Request) (*mobilesecurityservicev1alpha1.MobileSecurityService, error) {
 	instance := &mobilesecurityservicev1alpha1.MobileSecurityService{}
 	//Fetch the MobileSecurityService instance
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	return instance, err
 }
-
 
 //fetchRoute returns the Route resource created for this instance
 func (r *ReconcileMobileSecurityService) fetchRoute(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService) (*routev1.Route, error) {
@@ -35,6 +35,14 @@ func (r *ReconcileMobileSecurityService) fetchService(reqLogger logr.Logger, ins
 	reqLogger.Info("Checking if the service already exists")
 	service := &corev1.Service{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, service)
+	return service, err
+}
+
+//fetchServerService returns the service resource created for this instance
+func (r *ReconcileMobileSecurityService) fetchServerService(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityService) (*corev1.Service, error) {
+	reqLogger.Info("Checking if the service already exists")
+	service := &corev1.Service{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: utils.SERVER_SERVICE_INSTANCE_NAME, Namespace: instance.Namespace}, service)
 	return service, err
 }
 
@@ -53,5 +61,3 @@ func (r *ReconcileMobileSecurityService) fetchConfigMap(reqLogger logr.Logger, i
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: utils.GetConfigMapName(instance), Namespace: instance.Namespace}, configMap)
 	return configMap, err
 }
-
-

--- a/pkg/controller/mobilesecurityservice/route.go
+++ b/pkg/controller/mobilesecurityservice/route.go
@@ -22,7 +22,7 @@ func (r *ReconcileMobileSecurityService) buildRoute(m *mobilesecurityservicev1al
 		Spec: routev1.RouteSpec{
 			To: routev1.RouteTargetReference{
 				Kind: "Service",
-				Name: m.Name,
+				Name: utils.PROXY_SERVICE_INSTANCE_NAME,
 			},
 			Port: &routev1.RoutePort{
 				TargetPort: intstr.FromString("web"),

--- a/pkg/controller/mobilesecurityservice/services.go
+++ b/pkg/controller/mobilesecurityservice/services.go
@@ -2,6 +2,7 @@ package mobilesecurityservice
 
 import (
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +29,36 @@ func (r *ReconcileMobileSecurityService) buildService(m *mobilesecurityservicev1
 					Port:       80,
 					Protocol:   "TCP",
 					Name:       "web",
+				},
+			},
+			SessionAffinity: "None",
+		},
+	}
+	// Set MobileSecurityService instance as the owner and controller
+	controllerutil.SetControllerReference(m, ser, r.scheme)
+	return ser
+}
+
+func (r *ReconcileMobileSecurityService) buildServerService(m *mobilesecurityservicev1alpha1.MobileSecurityService) *corev1.Service {
+	ls := getAppLabels(m.Name)
+	ser := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      utils.SERVER_SERVICE_INSTANCE_NAME,
+			Namespace: m.Namespace,
+			Labels:    ls,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: ls,
+			Type:     corev1.ServiceTypeClusterIP,
+			Ports: []corev1.ServicePort{
+				{
+					Port:     m.Spec.Port,
+					Protocol: "TCP",
+					Name:     "server",
 				},
 			},
 			SessionAffinity: "None",

--- a/pkg/controller/mobilesecurityservice/services.go
+++ b/pkg/controller/mobilesecurityservice/services.go
@@ -11,12 +11,12 @@ import (
 )
 
 //buildService returns the service resource
-func (r *ReconcileMobileSecurityService) buildService(m *mobilesecurityservicev1alpha1.MobileSecurityService) *corev1.Service {
+func (r *ReconcileMobileSecurityService) buildProxyService(m *mobilesecurityservicev1alpha1.MobileSecurityService) *corev1.Service {
 	ls := getAppLabels(m.Name)
 	targetPort := intstr.FromInt(int(m.Spec.OAuthPort))
 	ser := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      m.Name,
+			Name:      utils.PROXY_SERVICE_INSTANCE_NAME,
 			Namespace: m.Namespace,
 			Labels:    ls,
 		},
@@ -27,11 +27,9 @@ func (r *ReconcileMobileSecurityService) buildService(m *mobilesecurityservicev1
 				{
 					TargetPort: targetPort,
 					Port:       80,
-					Protocol:   "TCP",
 					Name:       "web",
 				},
 			},
-			SessionAffinity: "None",
 		},
 	}
 	// Set MobileSecurityService instance as the owner and controller
@@ -39,29 +37,22 @@ func (r *ReconcileMobileSecurityService) buildService(m *mobilesecurityservicev1
 	return ser
 }
 
-func (r *ReconcileMobileSecurityService) buildServerService(m *mobilesecurityservicev1alpha1.MobileSecurityService) *corev1.Service {
+func (r *ReconcileMobileSecurityService) buildApplicationService(m *mobilesecurityservicev1alpha1.MobileSecurityService) *corev1.Service {
 	ls := getAppLabels(m.Name)
 	ser := &corev1.Service{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Service",
-		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      utils.SERVER_SERVICE_INSTANCE_NAME,
+			Name:      utils.APPLICATION_SERVICE_INSTANCE_NAME,
 			Namespace: m.Namespace,
 			Labels:    ls,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: ls,
-			Type:     corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
-					Port:     m.Spec.Port,
-					Protocol: "TCP",
-					Name:     "server",
+					Port: m.Spec.Port,
+					Name: "server",
 				},
 			},
-			SessionAffinity: "None",
 		},
 	}
 	// Set MobileSecurityService instance as the owner and controller

--- a/pkg/controller/mobilesecurityservice/services.go
+++ b/pkg/controller/mobilesecurityservice/services.go
@@ -22,7 +22,6 @@ func (r *ReconcileMobileSecurityService) buildProxyService(m *mobilesecurityserv
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: ls,
-			Type:     corev1.ServiceTypeClusterIP,
 			Ports: []corev1.ServicePort{
 				{
 					TargetPort: targetPort,

--- a/pkg/controller/mobilesecurityservice/status.go
+++ b/pkg/controller/mobilesecurityservice/status.go
@@ -14,7 +14,7 @@ import (
 )
 
 //updateStatus returns error when status regards the all required resources could not be updated
-func (r *ReconcileMobileSecurityService) updateStatus(reqLogger logr.Logger, configMapStatus *corev1.ConfigMap, deploymentStatus *v1beta1.Deployment, serviceStatus *corev1.Service, routeStatus *routev1.Route, request reconcile.Request) error {
+func (r *ReconcileMobileSecurityService) updateStatus(reqLogger logr.Logger, configMapStatus *corev1.ConfigMap, deploymentStatus *v1beta1.Deployment, serviceStatus *corev1.Service, serverServiceStatus *corev1.Service, routeStatus *routev1.Route, request reconcile.Request) error {
 	reqLogger.Info("Updating App Status for the MobileSecurityService")
 	// Get the latest version of the CR
 	instance, err := r.fetchInstance(reqLogger, request)
@@ -23,7 +23,7 @@ func (r *ReconcileMobileSecurityService) updateStatus(reqLogger logr.Logger, con
 	}
 
 	//Check if all required objects are created
-	if len(configMapStatus.UID) < 1 && len(deploymentStatus.UID) < 1 && len(serviceStatus.UID) < 1 && len(routeStatus.Name) < 1 {
+	if len(configMapStatus.UID) < 1 && len(deploymentStatus.UID) < 1 && len(serviceStatus.UID) < 1 && len(serverServiceStatus.UID) < 1 && len(routeStatus.Name) < 1 {
 		err := fmt.Errorf("Failed to get OK Status for MobileSecurityService")
 		reqLogger.Error(err, "One of the resources are not created", "MobileSecurityService.Namespace", instance.Namespace, "MobileSecurityService.Name", instance.Name)
 		return err

--- a/pkg/controller/mobilesecurityservice/status_test.go
+++ b/pkg/controller/mobilesecurityservice/status_test.go
@@ -24,11 +24,12 @@ func TestReconcileMobileSecurityService_updateStatus(t *testing.T) {
 		scheme   *runtime.Scheme
 	}
 	type args struct {
-		request    reconcile.Request
-		configMap  *corev1.ConfigMap
-		deployment *v1beta1.Deployment
-		service    *corev1.Service
-		route      *routev1.Route
+		request            reconcile.Request
+		configMap          *corev1.ConfigMap
+		deployment         *v1beta1.Deployment
+		proxyService       *corev1.Service
+		applicationService *corev1.Service
+		route              *routev1.Route
 	}
 	tests := []struct {
 		name    string
@@ -68,7 +69,13 @@ func TestReconcileMobileSecurityService_updateStatus(t *testing.T) {
 						Kind:       "Deployment",
 					},
 				},
-				service: &corev1.Service{
+				proxyService: &corev1.Service{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Service",
+					},
+				},
+				applicationService: &corev1.Service{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "v1",
 						Kind:       "Service",
@@ -92,7 +99,7 @@ func TestReconcileMobileSecurityService_updateStatus(t *testing.T) {
 
 			reqLogger := log.WithValues("Request.Namespace", tt.args.request.Namespace, "Request.Name", tt.args.request.Name)
 
-			if err := r.updateStatus(reqLogger, tt.args.configMap, tt.args.deployment, tt.args.service, tt.args.route, tt.args.request); (err != nil) != tt.wantErr {
+			if err := r.updateStatus(reqLogger, tt.args.configMap, tt.args.deployment, tt.args.proxyService, tt.args.applicationService, tt.args.route, tt.args.request); (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileMobileSecurityService.updateStatus() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/controller/mobilesecurityserviceapp/fetches.go
+++ b/pkg/controller/mobilesecurityserviceapp/fetches.go
@@ -2,6 +2,7 @@ package mobilesecurityserviceapp
 
 import (
 	"context"
+
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
 	"github.com/aerogear/mobile-security-service-operator/pkg/models"
 	"github.com/aerogear/mobile-security-service-operator/pkg/service"
@@ -13,13 +14,12 @@ import (
 
 // Request object not found, could have been deleted after reconcile request.
 // Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-func (r *ReconcileMobileSecurityServiceApp) fetchInstance( reqLogger logr.Logger, request reconcile.Request) (*mobilesecurityservicev1alpha1.MobileSecurityServiceApp, error) {
+func (r *ReconcileMobileSecurityServiceApp) fetchInstance(reqLogger logr.Logger, request reconcile.Request) (*mobilesecurityservicev1alpha1.MobileSecurityServiceApp, error) {
 	instance := &mobilesecurityservicev1alpha1.MobileSecurityServiceApp{}
 	//Fetch the MobileSecurityServiceApp instance
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	return instance, err
 }
-
 
 //fetchSDKConfigMap returns the config map resource created for this instance
 func (r *ReconcileMobileSecurityServiceApp) fetchSDKConfigMap(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp) (*corev1.ConfigMap, error) {
@@ -30,6 +30,6 @@ func (r *ReconcileMobileSecurityServiceApp) fetchSDKConfigMap(reqLogger logr.Log
 }
 
 //fetchBindAppRestServiceByAppID return app struct from Mobile Security Service Project/REST API or error
-func fetchBindAppRestServiceByAppID(serviceURL string, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp, reqLogger logr.Logger) (models.App, error){
+func fetchBindAppRestServiceByAppID(serviceURL string, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp, reqLogger logr.Logger) (*models.App, error) {
 	return service.GetAppFromServiceByRestApi(serviceURL, instance.Spec.AppId, reqLogger)
 }

--- a/pkg/controller/mobilesecurityserviceapp/finalizer.go
+++ b/pkg/controller/mobilesecurityserviceapp/finalizer.go
@@ -2,13 +2,15 @@ package mobilesecurityserviceapp
 
 import (
 	"context"
+
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 //addFinalizer will add the Finalizer metadata in the Mobile Security Service App CR
-func (r *ReconcileMobileSecurityServiceApp) addFinalizer(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp,  request reconcile.Request) error {
+func (r *ReconcileMobileSecurityServiceApp) addFinalizer(reqLogger logr.Logger, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp, request reconcile.Request) error {
 	if len(instance.GetFinalizers()) < 1 && instance.GetDeletionTimestamp() == nil {
 		reqLogger.Info("Adding Finalizer for the MobileSecurityServiceApp")
 
@@ -31,9 +33,8 @@ func (r *ReconcileMobileSecurityServiceApp) addFinalizer(reqLogger logr.Logger, 
 	return nil
 }
 
-
 //removeFinalizer returns error when the app still not deleted in the REST Service
-func (r *ReconcileMobileSecurityServiceApp) removeFinalizer(serviceAPI string,reqLogger logr.Logger, request reconcile.Request) error {
+func (r *ReconcileMobileSecurityServiceApp) removeFinalizer(serviceAPI string, reqLogger logr.Logger, request reconcile.Request) error {
 
 	// Get the latest version of CR
 	instance, err := r.fetchInstance(reqLogger, request)
@@ -43,7 +44,7 @@ func (r *ReconcileMobileSecurityServiceApp) removeFinalizer(serviceAPI string,re
 
 	if len(instance.GetFinalizers()) > 0 && instance.GetDeletionTimestamp() != nil {
 		reqLogger.Info("Removing Finalizer for the MobileSecurityServiceApp")
-		if app, err := fetchBindAppRestServiceByAppID(serviceAPI, instance, reqLogger);  err != nil || app.ID != "" {
+		if app, err := fetchBindAppRestServiceByAppID(serviceAPI, instance, reqLogger); err != nil || app.ID != "" {
 			reqLogger.Error(err, "Unable to delete app", "App.appId", instance.Spec.AppId, "app.ID", app.ID)
 			return err
 		}

--- a/pkg/controller/mobilesecurityserviceapp/helpers.go
+++ b/pkg/controller/mobilesecurityserviceapp/helpers.go
@@ -2,13 +2,14 @@ package mobilesecurityserviceapp
 
 import (
 	"encoding/json"
+
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
 	"github.com/aerogear/mobile-security-service-operator/pkg/models"
 	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
 	"github.com/go-logr/logr"
 )
 
-const SDK  = "-sdk"
+const SDK = "-sdk"
 const FINALIZER = "finalizer.mobile-security-service.aerogear.com"
 
 // Returns an string map with the labels which wil be associated to the kubernetes/openshift objects
@@ -18,7 +19,7 @@ func getAppLabels(name string) map[string]string {
 }
 
 //To transform the object into a string with its json
-func getSdkConfigStringJsonFormat(sdk *models.SDKConfig) string{
+func getSdkConfigStringJsonFormat(sdk *models.SDKConfig) string {
 	jsonSdk, _ := json.MarshalIndent(sdk, "", "\t")
 	return string(jsonSdk)
 }

--- a/pkg/controller/mobilesecurityserviceapp/status.go
+++ b/pkg/controller/mobilesecurityserviceapp/status.go
@@ -3,9 +3,10 @@ package mobilesecurityserviceapp
 import (
 	"context"
 	"fmt"
+	"reflect"
+
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -48,7 +49,7 @@ func (r *ReconcileMobileSecurityServiceApp) updateSDKConfigMapStatus(reqLogger l
 }
 
 //updateAppStatus returns error when status regards the all required resources could not be updated
-func (r *ReconcileMobileSecurityServiceApp) updateBindStatus(serviceURL string,reqLogger logr.Logger, SDKConfigMapStatus *corev1.ConfigMap, request reconcile.Request) error {
+func (r *ReconcileMobileSecurityServiceApp) updateBindStatus(serviceURL string, reqLogger logr.Logger, SDKConfigMapStatus *corev1.ConfigMap, request reconcile.Request) error {
 	reqLogger.Info("Updating Bind App Status for the MobileSecurityServiceApp")
 
 	// Get the latest version of CR
@@ -70,7 +71,7 @@ func (r *ReconcileMobileSecurityServiceApp) updateBindStatus(serviceURL string,r
 		reqLogger.Error(err, "One of the resources are not created", "MobileSecurityServiceApp.Namespace", instance.Namespace, "MobileSecurityServiceApp.Name", instance.Name)
 		return err
 	}
-	status:= "OK"
+	status := "OK"
 
 	//Update Bind CR Status with OK
 	if !reflect.DeepEqual(status, instance.Status.BindStatus) {

--- a/pkg/controller/mobilesecurityservicedb/controller.go
+++ b/pkg/controller/mobilesecurityservicedb/controller.go
@@ -173,7 +173,7 @@ func (r *ReconcileMobileSecurityServiceDB) Reconcile(request reconcile.Request) 
 		// if the Instance cannot be found and/or its configMap was not created than the default values specified in its CR will be used
 		reqLogger.Info("Checking for service instance ...")
 		serviceInstance := &mobilesecurityservicev1alpha1.MobileSecurityService{}
-		r.client.Get(context.TODO(), types.NamespacedName{Name: utils.SERVICE_INSTANCE_NAME, Namespace: operatorNamespace}, serviceInstance)
+		r.client.Get(context.TODO(), types.NamespacedName{Name: "mobile-security-service", Namespace: operatorNamespace}, serviceInstance)
 		return r.create(instance, serviceInstance, DEEPLOYMENT, reqLogger)
 	}
 

--- a/pkg/service/client.go
+++ b/pkg/service/client.go
@@ -3,18 +3,19 @@ package service
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/aerogear/mobile-security-service-operator/pkg/models"
-	"github.com/go-logr/logr"
 	"net/http"
 	"strings"
+
+	"github.com/aerogear/mobile-security-service-operator/pkg/models"
+	"github.com/go-logr/logr"
 )
 
 //DeleteAppFromServiceByRestAPI delete the app object in the service
-func DeleteAppFromServiceByRestAPI(serviceAPI string, id string, reqLogger logr.Logger ) error {
-	reqLogger.Info( "Calling REST Service to DELETE app", "serviceAPI", serviceAPI, "App.id", id )
+func DeleteAppFromServiceByRestAPI(serviceAPI string, id string, reqLogger logr.Logger) error {
+	reqLogger.Info("Calling REST Service to DELETE app", "serviceAPI", serviceAPI, "App.id", id)
 	//Create the DELETE request
-	url:= serviceAPI + "/apps/" + id
-	req, err := http.NewRequest(http.MethodDelete, url ,nil)
+	url := serviceAPI + "/apps/" + id
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		reqLogger.Error(err, "Unable to create DELETE request", "HTTPMethod", http.MethodDelete, "url", url)
@@ -24,21 +25,21 @@ func DeleteAppFromServiceByRestAPI(serviceAPI string, id string, reqLogger logr.
 	//Do the request
 	client := &http.Client{}
 	response, err := client.Do(req)
-	defer response.Body.Close()
 
 	if err != nil || 204 != response.StatusCode {
 		reqLogger.Error(err, "HTTP StatusCode not expected", "HTTPMethod", http.MethodDelete, "url", url, "response.StatusCode", response.StatusCode)
 		return err
 	}
 
-	reqLogger.Info("Successfully deleted app  ...",  "App.Id:", id)
+	defer response.Body.Close()
+
+	reqLogger.Info("Successfully deleted app  ...", "App.Id:", id)
 	return nil
 }
 
-
 //CreateAppByRestAPI create the app object in the service
 func CreateAppByRestAPI(serviceAPI string, app models.App, reqLogger logr.Logger) error {
-	reqLogger.Info( "Calling Service to POST app", "serviceAPI", serviceAPI, "App", app )
+	reqLogger.Info("Calling Service to POST app", "serviceAPI", serviceAPI, "App", app)
 
 	// Create the object and parse for JSON
 	appJSON, err := json.Marshal(app)
@@ -48,8 +49,8 @@ func CreateAppByRestAPI(serviceAPI string, app models.App, reqLogger logr.Logger
 	}
 
 	//Create the POST request
-	url:= serviceAPI + "/apps"
-	req, err := http.NewRequest(http.MethodPost, url , strings.NewReader(string(appJSON)))
+	url := serviceAPI + "/apps"
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(string(appJSON)))
 	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		reqLogger.Error(err, "Unable to create POST request", "HTTPMethod", http.MethodPost, "url", url)
@@ -59,33 +60,34 @@ func CreateAppByRestAPI(serviceAPI string, app models.App, reqLogger logr.Logger
 	//Do the request
 	client := &http.Client{}
 	response, err := client.Do(req)
-	defer response.Body.Close()
 
 	if err != nil || 201 != response.StatusCode {
-		reqLogger.Error(err, "HTTP StatusCode not expected", "HTTPMethod", http.MethodPost, "url", url, "response.StatusCode", response.StatusCode )
+		reqLogger.Error(err, "HTTP StatusCode not expected", "HTTPMethod", http.MethodPost, "url", url, "response.StatusCode", response.StatusCode)
 		return err
 	}
 
-	reqLogger.Info("Successfully created app  ...",  "App:", app)
+	defer response.Body.Close()
+
+	reqLogger.Info("Successfully created app  ...", "App:", app)
 	return nil
 }
 
 //GetAppFromServiceByRestApi returns the app object from the service
 func GetAppFromServiceByRestApi(serviceAPI string, appId string, reqLogger logr.Logger) (models.App, error) {
-	reqLogger.Info( "Calling REST API to GET app", "serviceAPI", serviceAPI, "App.appId", appId )
+	reqLogger.Info("Calling REST API to GET app", "serviceAPI", serviceAPI, "App.appId", appId)
 
 	// Fill the record with the data from the JSON
 	// Transform the body request in the version struct
 	got := models.App{}
 
 	if appId == "" {
-		err := fmt.Errorf( "App without AppId", "App.AppId", appId)
-		return got, err
+		reqLogger.Info("App without AppId", "App.AppId", appId)
+		return got, nil
 	}
 
 	//Create the GET request
-	url:= serviceAPI + "/apps" +"?appId="+appId
-	req, err := http.NewRequest(http.MethodGet,  url, nil)
+	url := serviceAPI + "/apps" + "?appId=" + appId
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	reqLogger.Info("URL to get", "HTTPMethod", http.MethodGet, "url", url)
 	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
@@ -96,22 +98,22 @@ func GetAppFromServiceByRestApi(serviceAPI string, appId string, reqLogger logr.
 	//Do the request
 	client := &http.Client{}
 	response, err := client.Do(req)
-	defer response.Body.Close()
 	if err != nil {
 		reqLogger.Error(err, "Unable to execute GET request", "HTTPMethod", http.MethodGet, "url", url, "response.StatusCode", response.StatusCode)
 		return got, err
 	}
 
 	if 200 != response.StatusCode && 204 != response.StatusCode {
-		err := fmt.Errorf( "HTTP StatusCode not expected")
+		err := fmt.Errorf("HTTP StatusCode not expected")
 		reqLogger.Error(err, "HTTP StatusCode not expected", "HTTPMethod", http.MethodGet, "url", url, "response.StatusCode", response.StatusCode)
 		return got, err
 	}
 
 	var obj []models.App
 	err = json.NewDecoder(response.Body).Decode(&obj)
+
 	if err != nil {
-		reqLogger.Error(err, "Error when try to do decode the body response", "HTTPMethod", http.MethodGet, "url", url, "Response.Body", response.Body )
+		reqLogger.Error(err, "Error when try to do decode the body response", "HTTPMethod", http.MethodGet, "url", url, "Response.Body", response.Body)
 		return got, err
 	}
 
@@ -120,16 +122,18 @@ func GetAppFromServiceByRestApi(serviceAPI string, appId string, reqLogger logr.
 		return got, nil
 	}
 
+	defer response.Body.Close()
+
 	reqLogger.Info("App found in the Service", "App", obj[0])
 	return obj[0], nil
 }
 
 //UpdateAppNameByRestAPI will update name of the APP in the Service
 func UpdateAppNameByRestAPI(serviceAPI string, app models.App, reqLogger logr.Logger) error {
-	reqLogger.Info( "Calling Service to update app name", "serviceAPI", serviceAPI, "App", app )
+	reqLogger.Info("Calling Service to update app name", "serviceAPI", serviceAPI, "App", app)
 
 	//Create the DELETE request
-	url:= serviceAPI + "/apps" +app.ID
+	url := serviceAPI + "/apps" + app.ID
 	appJSON, err := json.Marshal(app)
 
 	if err != nil {
@@ -137,7 +141,7 @@ func UpdateAppNameByRestAPI(serviceAPI string, app models.App, reqLogger logr.Lo
 		return err
 	}
 
-	req, err := http.NewRequest(http.MethodPatch, url ,strings.NewReader(string(appJSON)))
+	req, err := http.NewRequest(http.MethodPatch, url, strings.NewReader(string(appJSON)))
 	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		reqLogger.Error(err, "Unable to create PATCH request to update app name", "HTTPMethod", http.MethodPatch, "url", url)
@@ -153,6 +157,6 @@ func UpdateAppNameByRestAPI(serviceAPI string, app models.App, reqLogger logr.Lo
 	}
 	defer response.Body.Close()
 
-	reqLogger.Info("Successfully updated app name ...",  "App", app)
+	reqLogger.Info("Successfully updated app name ...", "App", app)
 	return nil
 }

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -1,20 +1,15 @@
 package service
 
 import (
-	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
-	routev1 "github.com/openshift/api/route/v1"
+	"fmt"
 
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
 )
 
 const ENDPOINT_API = "/api"
 
-//Return the router host URL
-func GetServiceURL(route *routev1.Route, serviceInstance *mobilesecurityservicev1alpha1.MobileSecurityService) string{
-	return serviceInstance.Spec.ClusterProtocol + "://" + route.Status.Ingress[0].Host
-}
-
 //Return REST Service API
-func GetServiceAPIURL(route *routev1.Route, serviceInstance *mobilesecurityservicev1alpha1.MobileSecurityService) string{
-	return GetServiceURL(route,serviceInstance) + ENDPOINT_API
+func GetServiceAPIURL(serviceInstance *mobilesecurityservicev1alpha1.MobileSecurityService) string {
+	return serviceInstance.Spec.ClusterProtocol + "://" + utils.SERVER_SERVICE_INSTANCE_NAME + ":" + fmt.Sprint(serviceInstance.Spec.Port) + ENDPOINT_API
 }
-

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -10,6 +10,6 @@ import (
 const ENDPOINT_API = "/api"
 
 //Return REST Service API
-func GetServiceAPIURL(serviceInstance *mobilesecurityservicev1alpha1.MobileSecurityService) string {
-	return serviceInstance.Spec.ClusterProtocol + "://" + utils.SERVER_SERVICE_INSTANCE_NAME + ":" + fmt.Sprint(serviceInstance.Spec.Port) + ENDPOINT_API
+func GetServiceAPIURL(mssInstance *mobilesecurityservicev1alpha1.MobileSecurityService) string {
+	return mssInstance.Spec.ClusterProtocol + "://" + utils.APPLICATION_SERVICE_INSTANCE_NAME + ":" + fmt.Sprint(mssInstance.Spec.Port) + ENDPOINT_API
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -15,6 +15,7 @@ import (
 // The namespaces should be informed split by ";".
 const APP_NAMESPACE_ENV_VAR = "APP_NAMESPACES"
 const SERVICE_INSTANCE_NAME = "mobile-security-service"
+const SERVER_SERVICE_INSTANCE_NAME = "mobile-security-server"
 
 var log = logf.Log.WithName("mobile-security-service-operator.utils")
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -14,8 +14,8 @@ import (
 // which is the namespace where the APP CR can applied.
 // The namespaces should be informed split by ";".
 const APP_NAMESPACE_ENV_VAR = "APP_NAMESPACES"
-const SERVICE_INSTANCE_NAME = "mobile-security-service"
-const SERVER_SERVICE_INSTANCE_NAME = "mobile-security-server"
+const PROXY_SERVICE_INSTANCE_NAME = "mobile-security-service-proxy"
+const APPLICATION_SERVICE_INSTANCE_NAME = "mobile-security-service-application"
 
 var log = logf.Log.WithName("mobile-security-service-operator.utils")
 


### PR DESCRIPTION
## Motivation
[JIRA Comment](https://issues.jboss.org/browse/AEROGEAR-8987?focusedCommentId=13732533&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13732533)

Please note there are some changes here to the creation and deletion logic. These can be removed based on the other changes being made by @camilamacedo86 in another pr.

## What
An additional Service is added by the operator which is not fronted by a Route to be used by the operator in order to interact with the service as required by the consumption pr.

## Verification Steps

1. Using this image: `quay.io/laurafitzgerald/mobile-security-service-operator:0.1.0-dev-ag8987-2` 
2. Run `make create-all`
3. Verify access to the server and additionally that the make delete and update of apps is working correctly.
a) a new Service is created titled `security-service-server` which can be seen in the console
b) Operator updates the app in the service as required by the state of the app cr
   i) create app
   `oc new-project mobile-security-service-apps`
   `make create-app`
   Verify the app has been created in the UI
   ii) update app
   Update the name in the app cr
   Verify the app name is updated in the UI
   iii) delete app
  `make delete-app`
   Verify the app has been deleted from the UI

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
