### PR TITLE
fix(Makefile) : Use var for the operator namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,13 +73,13 @@ run-local:
 
 .PHONY: create-all
 create-all:
-	@echo Create Mobile Security Service Operator and Service in the namespace "mobile-security-service-operator":
+	@echo Create Mobile Security Service Operator and Service in the namespace ${NAMESPACE}:
 	make create-oper
 	make create-service-and-db
 
 .PHONY: delete-all
 delete-all:
-	@echo Delete Mobile Security Service Operator, Service and namespace "mobile-security-service-operator":
+	@echo Delete Mobile Security Service Operator, Service and namespace ${NAMESPACE}:
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityserviceapp_crd.yaml
@@ -117,7 +117,7 @@ delete-oper:
 	- kubectl delete -f deploy/operator.yaml
 	- kubectl delete -f deploy/role.yaml
 	- kubectl delete -f deploy/role_binding.yaml
-	- kubectl delete namespace mobile-security-service-operator
+	- kubectl delete namespace ${NAMESPACE}
 
 .PHONY: create-service-and-db
 create-service-and-db:


### PR DESCRIPTION
## Motivation
Local tests

## What
Fix Makefile to use the var for the operator namespace.

## Verification Steps
- Use this PR to run make-create and make-delete. 
- Ensure that all be created with success. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<img width="1650" alt="Screenshot 2019-05-16 at 10 34 37" src="https://user-images.githubusercontent.com/7708031/57843447-394ba700-77c6-11e9-9234-5306b6eb548d.png">

