### PR TITLE
fix(refec) - Remove metav1.TypeMeta which is not required in the objects

### DIFF
--- a/pkg/controller/mobilesecurityservice/configmaps.go
+++ b/pkg/controller/mobilesecurityservice/configmaps.go
@@ -11,10 +11,6 @@ import (
 // Returns the ConfigMap with the properties used to setup/config the Mobile Security Service Project
 func (r *ReconcileMobileSecurityService) buildConfigMap(m *mobilesecurityservicev1alpha1.MobileSecurityService) *corev1.ConfigMap {
 	ser := &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.GetConfigMapName(m),
 			Namespace: m.Namespace,

--- a/pkg/controller/mobilesecurityservice/deployments.go
+++ b/pkg/controller/mobilesecurityservice/deployments.go
@@ -16,10 +16,6 @@ func (r *ReconcileMobileSecurityService) buildDeployment(m *mobilesecurityservic
 	ls := getAppLabels(m.Name)
 	replicas := m.Spec.Size
 	dep := &v1beta1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "extensions/v1beta1",
-			Kind:       "Deployment",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name,
 			Namespace: m.Namespace,

--- a/pkg/controller/mobilesecurityservice/route.go
+++ b/pkg/controller/mobilesecurityservice/route.go
@@ -14,10 +14,6 @@ func (r *ReconcileMobileSecurityService) buildRoute(m *mobilesecurityservicev1al
 
 	ls := getAppLabels(m.Name)
 	route := &routev1.Route{
-		TypeMeta: v1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Route",
-		},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      utils.GetRouteName(m),
 			Namespace: m.Namespace,

--- a/pkg/controller/mobilesecurityservice/services.go
+++ b/pkg/controller/mobilesecurityservice/services.go
@@ -14,10 +14,6 @@ func (r *ReconcileMobileSecurityService) buildService(m *mobilesecurityservicev1
 	ls := getAppLabels(m.Name)
 	targetPort := intstr.FromInt(int(m.Spec.OAuthPort))
 	ser := &corev1.Service{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Service",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name,
 			Namespace: m.Namespace,

--- a/pkg/controller/mobilesecurityserviceapp/configmaps.go
+++ b/pkg/controller/mobilesecurityserviceapp/configmaps.go
@@ -10,10 +10,6 @@ import (
 // Returns the ConfigMap with the properties used to setup/config the Mobile Security Service Project
 func (r *ReconcileMobileSecurityServiceApp) buildAppSDKConfigMap(m *mobilesecurityservicev1alpha1.MobileSecurityServiceApp, serviceURL string) *corev1.ConfigMap {
 	configMap := &corev1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      getSDKConfigMapName(m),
 			Namespace: m.Namespace,

--- a/pkg/controller/mobilesecurityservicedb/pvs.go
+++ b/pkg/controller/mobilesecurityservicedb/pvs.go
@@ -12,10 +12,6 @@ import (
 func (r *ReconcileMobileSecurityServiceDB) buildPVCForDB(m *mobilesecurityservicev1alpha1.MobileSecurityServiceDB) *corev1.PersistentVolumeClaim {
 	ls := getDBLabels(m.Name)
 	pv := &corev1.PersistentVolumeClaim{
-		TypeMeta: v1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "PersistentVolumeClaim",
-		},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      m.Name,
 			Namespace: m.Namespace,

--- a/pkg/controller/mobilesecurityservicedb/services.go
+++ b/pkg/controller/mobilesecurityservicedb/services.go
@@ -13,10 +13,6 @@ import (
 func (r *ReconcileMobileSecurityServiceDB) buildDBService(m *mobilesecurityservicev1alpha1.MobileSecurityServiceDB) *corev1.Service {
 	ls := getDBLabels(m.Name)
 	ser := &corev1.Service{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Service",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      m.Name,
 			Namespace: m.Namespace,


### PR DESCRIPTION
## Motivation
Remove
## What
Remove metav1.TypeMeta which is not required in the objects

## Why
Following good practices and do not add implicit and unnecessary info.

## Verification Steps
Use the image `docker.io/cmacedo/mobile-security-service-operator:REF` to install the operator and check that will still be working fine. 
 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
