### PR TITLE
ref(update status) : not required use deep equals to compare the names

### DIFF
--- a/pkg/controller/mobilesecurityservice/controller.go
+++ b/pkg/controller/mobilesecurityservice/controller.go
@@ -197,7 +197,6 @@ func (r *ReconcileMobileSecurityService) Reconcile(request reconcile.Request) (r
 	}
 
 	//Update status for ConfigMap
-
 	configMapStatus, err := r.updateConfigMapStatus(reqLogger, request)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/mobilesecurityservice/status.go
+++ b/pkg/controller/mobilesecurityservice/status.go
@@ -67,7 +67,7 @@ func (r *ReconcileMobileSecurityService) updateConfigMapStatus(reqLogger logr.Lo
 	}
 
 	// Update ConfigMap Name
-	if !reflect.DeepEqual(configMapStatus.Name, instance.Status.ConfigMapName) {
+	if configMapStatus.Name != instance.Status.ConfigMapName {
 		// Get the latest version of the CR
 		instance, err := r.fetchInstance(reqLogger, request)
 		if err != nil {
@@ -104,7 +104,7 @@ func (r *ReconcileMobileSecurityService) updateDeploymentStatus(reqLogger logr.L
 	}
 
 	// Update the Deployment Name and Status
-	if !reflect.DeepEqual(deploymentStatus.Name, instance.Status.DeploymentName) || !reflect.DeepEqual(deploymentStatus.Status, instance.Status.DeploymentStatus) {
+	if deploymentStatus.Name != instance.Status.DeploymentName || !reflect.DeepEqual(deploymentStatus.Status, instance.Status.DeploymentStatus) {
 		// Get the latest version of the CR
 		instance, err := r.fetchInstance(reqLogger, request)
 		if err != nil {
@@ -142,7 +142,7 @@ func (r *ReconcileMobileSecurityService) updateServiceStatus(reqLogger logr.Logg
 	}
 
 	// Update the Service Status and Name
-	if !reflect.DeepEqual(serviceStatus.Name, instance.Status.ServiceName) || !reflect.DeepEqual(serviceStatus.Status, instance.Status.ServiceStatus) {
+	if serviceStatus.Name != instance.Status.ServiceName || !reflect.DeepEqual(serviceStatus.Status, instance.Status.ServiceStatus) {
 		// Get the latest version of the CR
 		instance, err := r.fetchInstance(reqLogger, request)
 		if err != nil {
@@ -184,7 +184,7 @@ func (r *ReconcileMobileSecurityService) updateRouteStatus(reqLogger logr.Logger
 	routeName := utils.GetRouteName(instance)
 
 	// Update the Route Status and Name
-	if !reflect.DeepEqual(routeName, instance.Status.RouteName) || !reflect.DeepEqual(route.Status, instance.Status.RouteStatus) {
+	if routeName != instance.Status.RouteName || !reflect.DeepEqual(route.Status, instance.Status.RouteStatus) {
 
 		// Get the latest version of the CR
 		instance, err := r.fetchInstance(reqLogger, request)

--- a/pkg/controller/mobilesecurityserviceapp/status.go
+++ b/pkg/controller/mobilesecurityserviceapp/status.go
@@ -27,7 +27,7 @@ func (r *ReconcileMobileSecurityServiceApp) updateSDKConfigMapStatus(reqLogger l
 	}
 
 	//Update CR Status with SDKConfigMap name
-	if !reflect.DeepEqual(SDKConfigMapStatus.Name, instance.Status.SDKConfigMapName) {
+	if SDKConfigMapStatus.Name != instance.Status.SDKConfigMapName {
 		// Get the latest version of CR
 		instance, err := r.fetchInstance(reqLogger, request)
 		if err != nil {

--- a/pkg/controller/mobilesecurityservicedb/status.go
+++ b/pkg/controller/mobilesecurityservicedb/status.go
@@ -66,7 +66,7 @@ func (r *ReconcileMobileSecurityServiceDB) updateDeploymentStatus(reqLogger logr
 		return deploymentStatus, err
 	}
 	// Update the Deployment Name and Status
-	if !reflect.DeepEqual(deploymentStatus.Name, instance.Status.DeploymentName) || !reflect.DeepEqual(deploymentStatus.Status, instance.Status.DeploymentStatus){
+	if deploymentStatus.Name != instance.Status.DeploymentName || !reflect.DeepEqual(deploymentStatus.Status, instance.Status.DeploymentStatus){
 		// Get the latest version of the instance CR
 		instance, err = r.fetchInstance(reqLogger, request)
 		if err != nil {
@@ -104,7 +104,7 @@ func (r *ReconcileMobileSecurityServiceDB) updateServiceStatus(reqLogger logr.Lo
 	}
 
 	// Update the Service Name and Status
-	if !reflect.DeepEqual(serviceStatus.Name, instance.Status.ServiceName) || !reflect.DeepEqual(serviceStatus.Status, instance.Status.ServiceStatus)  {
+	if serviceStatus.Name != instance.Status.ServiceName || !reflect.DeepEqual(serviceStatus.Status, instance.Status.ServiceStatus)  {
 		// Get the latest version of the instance CR
 		instance, err = r.fetchInstance(reqLogger, request)
 		if err != nil {
@@ -142,7 +142,7 @@ func (r *ReconcileMobileSecurityServiceDB) updatePvcStatus(reqLogger logr.Logger
 	}
 
 	// Update CR with PVC name
-	if !reflect.DeepEqual(pvcStatus.Name, instance.Status.PersistentVolumeClaimName) {
+	if pvcStatus.Name != instance.Status.PersistentVolumeClaimName {
 		// Get the latest version of the instance CR
 		instance, err = r.fetchInstance(reqLogger, request)
 		if err != nil {


### PR DESCRIPTION
## Motivation
Comments raised in another PR by @craicoverflow 

## What
Remove deep equals check when the conditional is just to check the name "string"
 
## Why
- Good practice
- Better performance

## Verification Steps
1. Install the operator by using the image `docker.io/cmacedo/mobile-security-service-operator:REF-STATUS`
2. Run `make create-all`
3. Check if all were installed with success and if the MSS and MSS BD CR has the status fields filled 

<img width="984" alt="Screenshot 2019-05-16 at 13 33 23" src="https://user-images.githubusercontent.com/7708031/57854070-3b6e2f80-77df-11e9-8546-d57dd9b57e6d.png">
<img width="958" alt="Screenshot 2019-05-16 at 13 33 08" src="https://user-images.githubusercontent.com/7708031/57854072-3c06c600-77df-11e9-8f4c-732df2ec9a14.png">


## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

