### PR TITLE
feat(MSS) : Allow the MSS CR be able to specify how much resources …

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -157,6 +157,30 @@ NOTE:
 * All values used in the default configuration are sourced from the config-map which is managed and created by the Operator. This config map will be created in the Operator namespace and its name is defined by the attribute `configMapName` in the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService CR].
 * If the name of this ConfigMap is not specified then the name of the Mobile Security Service instance will be used instead.
 
+=======
+=== Database resources required by the Mobile Security Service
+
+In the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService CR] you are able to define the quantity of resources required and its limits for the database which will be used by this service. Following the fields.
+
+[source,yaml]
+----
+  databaseMemoryLimit: "512Mi"
+  databaseMemoryRequest: "512Mi"
+  databaseStorageRequest: "1Gi"
+----
+
+NOTE: This values are optional and if be not defined the Database will be installed with your own default configurations specified in its link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml[MobileSecurityServiceDB CR].
+
+=== Configure roles for non-privileged users
+
+By executing the following commands you will create the required roles which allow the <user> to create the Mobile Security Service Application and Database in their namespaces so it is not required to be logged in to the system:admin user. However, the Mobile Security Service Operator is cluster scoped and will still only accessible to the system:admin user.
+
+[source,shell]
+----
+$ oc create rolebinding developer-mobile-security-service-operator --role=mobile-security-service-operator --user=<user>
+$ oc create rolebinding developer-mobile-security-service --role=mobile-security-service --user=<user>
+----
+
 === Namespaces for the MobileSecurityServiceCR
 
 This operator will just working with the namespaces which are specified in the environment variable `APP_NAMESPACES` and the link:./deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml[MobileSecurityServiceApp CR] which be applied in a NAMESPACE which was not defined on it will be ignored. See its configuration into the link:./deploy/operator.yaml[operator.yaml] file.

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
@@ -32,3 +32,9 @@ spec:
   #    The DB will looking for this ConfigMap to get the Env Values variables
   configMapName: "mobile-security-service-config"
   routeName: "route"
+  # The following config is optional. These values defined the resources which the MSS Service needs
+  # for the database which will used by it.
+  # NOTE: If this values be not informed then the DB will be installed/config with its own default configurations.
+  databaseMemoryLimit: "512Mi"
+  databaseMemoryRequest: "512Mi"
+  databaseStorageRequest: "1Gi"

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservice_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservice_types.go
@@ -41,6 +41,13 @@ type MobileSecurityServiceSpec struct {
 	ConfigMapName           string `json:"configMapName,omitempty"`
 	RouteName               string `json:"routeName,omitempty"`
 	SkipNamespaceValidation bool   `json:"skipNamespaceValidation,omitempty"`
+
+	//CR Optional configuration values for the Database which will be used by it
+	// If the values be not specified then DB will be installed/config with its default definitions
+	DatabaseMemoryLimit    string `json:"databaseMemoryLimit,omitempty"`
+	DatabaseMemoryRequest  string `json:"databaseMemoryRequest,omitempty"`
+	DatabaseStorageRequest string `json:"databaseStorageRequest,omitempty"`
+
 }
 
 // MobileSecurityServiceStatus defines the observed state of MobileSecurityService

--- a/pkg/controller/mobilesecurityservicedb/controller.go
+++ b/pkg/controller/mobilesecurityservicedb/controller.go
@@ -115,7 +115,7 @@ func (r *ReconcileMobileSecurityServiceDB) buildFactory(instance *mobilesecurity
 	reqLogger.Info("Check "+kind, "into the namespace", instance.Namespace)
 	switch kind {
 	case PVC:
-		return r.buildPVCForDB(instance), nil
+		return r.buildPVCForDB(instance, serviceInstance), nil
 	case DEEPLOYMENT:
 		return r.buildDBDeployment(instance, serviceInstance), nil
 	case SERVICE:

--- a/pkg/controller/mobilesecurityservicedb/deployments.go
+++ b/pkg/controller/mobilesecurityservicedb/deployments.go
@@ -93,10 +93,10 @@ func (r *ReconcileMobileSecurityServiceDB) buildDBDeployment(m *mobilesecurityse
 						},
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse(m.Spec.DatabaseMemoryLimit),
+								corev1.ResourceMemory: resource.MustParse(getDatabaseMemoryLimit(m,serviceInstance)),
 							},
 							Requests: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse(m.Spec.DatabaseMemoryRequest),
+								corev1.ResourceMemory: resource.MustParse(getDatabaseMemoryRequest(m,serviceInstance)),
 							},
 						},
 						TerminationMessagePath: "/dev/termination-log",

--- a/pkg/controller/mobilesecurityservicedb/helpers.go
+++ b/pkg/controller/mobilesecurityservicedb/helpers.go
@@ -93,3 +93,32 @@ func (r *ReconcileMobileSecurityServiceDB) getDatabasePasswordEnvVar(m *mobilese
 		Value: m.Spec.DatabasePassword,
 	}
 }
+
+//getDatabaseMemoryLimit return the memory limit that should be used to setup it.
+func getDatabaseMemoryLimit(m *mobilesecurityservicev1alpha1.MobileSecurityServiceDB, serviceInstance *mobilesecurityservicev1alpha1.MobileSecurityService) string {
+	//If the application which will use this database defines an specific value then it should be used.
+	if serviceInstance == nil || serviceInstance.Spec.DatabaseMemoryLimit == "" {
+		return m.Spec.DatabaseMemoryLimit
+	}
+	return serviceInstance.Spec.DatabaseMemoryLimit
+
+}
+
+//getDatabaseMemoryLimit return the memory limit that should be used to setup it.
+func getDatabaseMemoryRequest(m *mobilesecurityservicev1alpha1.MobileSecurityServiceDB, serviceInstance *mobilesecurityservicev1alpha1.MobileSecurityService) string {
+	//If the application which will use this database defines an specific value then it should be used.
+	if  serviceInstance == nil || serviceInstance.Spec.DatabaseMemoryRequest == "" {
+		return m.Spec.DatabaseMemoryRequest
+	}
+	return serviceInstance.Spec.DatabaseMemoryRequest
+}
+
+//getDatabaseStorageRequest return the memory limit that should be used to setup it.
+func getDatabaseStorageRequest(m *mobilesecurityservicev1alpha1.MobileSecurityServiceDB, serviceInstance *mobilesecurityservicev1alpha1.MobileSecurityService) string {
+	//If the application which will use this database defines an specific value then it should be used.
+	if serviceInstance == nil || serviceInstance.Spec.DatabaseStorageRequest == "" {
+		return m.Spec.DatabaseStorageRequest
+	}
+	return serviceInstance.Spec.DatabaseStorageRequest
+
+}

--- a/pkg/controller/mobilesecurityservicedb/pvs.go
+++ b/pkg/controller/mobilesecurityservicedb/pvs.go
@@ -9,7 +9,7 @@ import (
 )
 
 //Returns the Deployment object for the Mobile Security Service Database
-func (r *ReconcileMobileSecurityServiceDB) buildPVCForDB(m *mobilesecurityservicev1alpha1.MobileSecurityServiceDB) *corev1.PersistentVolumeClaim {
+func (r *ReconcileMobileSecurityServiceDB) buildPVCForDB(m *mobilesecurityservicev1alpha1.MobileSecurityServiceDB, serviceInstance *mobilesecurityservicev1alpha1.MobileSecurityService) *corev1.PersistentVolumeClaim {
 	ls := getDBLabels(m.Name)
 	pv := &corev1.PersistentVolumeClaim{
 		ObjectMeta: v1.ObjectMeta{
@@ -23,7 +23,7 @@ func (r *ReconcileMobileSecurityServiceDB) buildPVCForDB(m *mobilesecurityservic
 			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse(m.Spec.DatabaseStorageRequest),
+					corev1.ResourceStorage: resource.MustParse(getDatabaseStorageRequest(m, serviceInstance)),
 				},
 			},
 		},


### PR DESCRIPTION
## Motivation
A debate in the refined backlog meeting today

## What
Allow the MSS object define/specify how much of the resources required for it works well should have the DB used by it. 

## Why
- What is required for the object MSS make sense be an attribute for it
- Attend the requirement which is that all specs required for the MSS can be performed in its CR

## How
- Add the optional Database resources requirements for the MSS CR
- If the MSS CR decided not to define it them the default config values for the DB will be used.

## Verification Steps
- With this PR and the image `docker.io/cmacedo/mobile-security-service-operator:DB-SPECS-FOR-MSS`
- Check that all was installed with success after run `make create-all`
- Check the changes in the README.

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes


 
<img width="1132" alt="Screenshot 2019-05-16 at 14 13 51" src="https://user-images.githubusercontent.com/7708031/57856405-e03f3b80-77e4-11e9-8029-b45a14cd9718.png">
