### PR TITLE
feat(add-metrics): add metrics to the operator :(INTLY-1455)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ create-all:
 .PHONY: delete-all
 delete-all:
 	@echo Delete Mobile Security Service Operator, Service and namespace ${NAMESPACE}:
+	- kubectl delete -f deploy/service_monitor.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityserviceapp_crd.yaml
@@ -97,6 +98,9 @@ delete-all:
 create-oper:
 	@echo Create Mobile Security Service Operator:
 	- oc new-project ${NAMESPACE}
+	- kubectl label namespace ${NAMESPACE} monitoring-key=middleware
+	- kubectl create -f deploy/service_monitor.yaml
+	- kubectl create -f deploy/operator_service.yaml -n ${NAMESPACE}
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityserviceapp_crd.yaml

--- a/README.adoc
+++ b/README.adoc
@@ -142,6 +142,22 @@ $ make delete-all
 
 == Configuration and Options
 
+=== Metrics
+
+The application-monitoring stack provisioned by the
+https://github.com/integr8ly/application-monitoring-operator[application-monitoring-operator]
+can be used to gather metrics from the operator here.  Once you have
+provisioned that (or the ServiceMonitor CRD at a minimum), it is configured by default with `make create-all` 
+you can run the following commands to configure it manually:
+
+[source,shell]
+----
+kubectl label namespace mobile-security-service monitoring-key=middleware
+kubectl create -f deploy/service_monitor.yaml
+kubectl create -f deploy/operator_service.yaml namespace mobile-security-service
+----
+
+
 === Oauth Configuration
 
 An Oauth Proxy container and the required configuration will be setup by default by the operator to provide authentication to the Mobile Security Service.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aerogear/mobile-security-service-operator/pkg/apis"
 	"github.com/aerogear/mobile-security-service-operator/pkg/controller"
 	routev1 "github.com/openshift/api/route/v1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
@@ -72,6 +73,13 @@ func main() {
 		log.Error(err, "")
 		os.Exit(1)
 	}
+	
+	// Get the Namespace
+	namespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		log.Error(err, "Failed to get watch namespace")
+		os.Exit(1)
+	}
 
 	//Create cmd Manager
 	//FIXME: We should not watch/cache all namespaces. However, the current version do not allow us pass the List of Namespaces.
@@ -79,6 +87,7 @@ func main() {
 	// See the PR which we are working on to update the deps and have this feature: https://github.com/operator-framework/operator-sdk/pull/1388
 	mgr, err := manager.New(cfg, manager.Options{
 		Namespace: "",
+		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort), 
 	})
 	if err != nil {
 		log.Error(err, "")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aerogear/mobile-security-service-operator/pkg/apis"
 	"github.com/aerogear/mobile-security-service-operator/pkg/controller"
 	routev1 "github.com/openshift/api/route/v1"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
@@ -74,13 +73,6 @@ func main() {
 		os.Exit(1)
 	}
 	
-	// Get the Namespace
-	namespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		log.Error(err, "Failed to get watch namespace")
-		os.Exit(1)
-	}
-
 	//Create cmd Manager
 	//FIXME: We should not watch/cache all namespaces. However, the current version do not allow us pass the List of Namespaces.
 	// The impl to allow do it is done and merged in the master branch of the lib but not released in an stable version.

--- a/deploy/operator_service.yaml
+++ b/deploy/operator_service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: mobile-security-service-operator
+  name: mobile-security-service-operator
+  namespace: mobile-security-service
+  resourceVersion: '66190'
+  selfLink: >-
+    /api/v1/namespaces/mobile-security-service/services/mobile-security-service-operator
+spec:
+  ports:
+    - name: metrics
+      port: 8383
+      protocol: TCP
+      targetPort: 8383
+  selector:
+    name: mobile-security-service-operator
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/deploy/service_monitor.yaml
+++ b/deploy/service_monitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    monitoring-key: middleware
+  name: mobile-security-service
+spec:
+  endpoints:
+    - path: /metrics
+      port: metrics
+  selector:
+    matchLabels:
+      name: mobile-security-service-operator


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-1455

## What
enable metrics for the mobile-security-service-operator

## Why
Required functionality for a managed service

## How
added a service monitor , and service and code to enable 

## Verification Steps
Add the steps required to check this change. Following an example.
 
- start minishift as outline at https://github.com/aerogear/mobile-security-service-operator#minishift-installation-and-setup
- deploy the https://github.com/integr8ly/application-monitoring-operator 
  - Note some Grafana and Prometheus images won't pull so change the image registry to `registry.access.redhat.com` to install
- clone this repo and checkout this branch
- `cd mobile-security-service-operator`
- change the operator image to point at dev this line https://github.com/aerogear/mobile-security-service-operator/blob/4bad63f27c63cefd2241cb2ba6a6e0ce0129e437/deploy/operator.yaml#L19
to 
```
          image: quay.io/aerogear/mobile-security-service-operator:0.1.0-dev
```
- Install the operator
```bash
make create-all
```
- Check the Prometheus to see if metrics are being gathered 
![Prometheus](https://user-images.githubusercontent.com/16667688/58016100-bd6a9b00-7af4-11e9-8944-fb0e223b024b.gif)


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 


 
