### PR TITLE
test(mobilesecurityservice): add unit tests for the database package (AEROGEAR-8952)

### DIFF
--- a/pkg/controller/mobilesecurityservice/controller_test.go
+++ b/pkg/controller/mobilesecurityservice/controller_test.go
@@ -324,8 +324,7 @@ func TestReconcileMobileSecurityService_Reconcile(t *testing.T) {
 		Namespace: mssInstance.Namespace,
 	}, service)
 	if err != nil {
-		t.Fatalf(err.Error())
-		t.Fatalf("get app service: (%v)", service)
+		t.Fatalf("get application service: (%v)", err)
 	}
 
 	res, err = r.Reconcile(req)
@@ -341,8 +340,7 @@ func TestReconcileMobileSecurityService_Reconcile(t *testing.T) {
 		Namespace: mssInstance.Namespace,
 	}, proxyService)
 	if err != nil {
-		t.Fatalf(err.Error())
-		t.Fatalf("get proxy service: (%v)", proxyService)
+		t.Fatalf("get proxy service: (%v)", err)
 	}
 
 	res, err = r.Reconcile(req)
@@ -361,35 +359,6 @@ func TestReconcileMobileSecurityService_Reconcile(t *testing.T) {
 		t.Fatalf("reconcile: (%v)", err)
 	}
 
-}
-
-func TestReconcileMobileSecurityService_Reconcile_InvalidInstance(t *testing.T) {
-	invalidInstance := &mssInstance
-	invalidInstance.Spec.ClusterProtocol = "https"
-
-	// objects to track in the fake client
-	objs := []runtime.Object{
-		&mssInstance,
-	}
-
-	r := buildReconcileWithFakeClientWithMocks(objs, t)
-
-	// mock request to simulate Reconcile() being called on an event for a watched resource
-	req := reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      mssInstance.Name,
-			Namespace: mssInstance.Namespace,
-		},
-	}
-
-	res, err := r.Reconcile(req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-
-	if !res.Requeue {
-		t.Error("reconcile did not requeue request as expected")
-	}
 }
 
 func TestReconcileMobileSecurityService_Reconcile_InvalidSpec(t *testing.T) {

--- a/pkg/controller/mobilesecurityservice/status_test.go
+++ b/pkg/controller/mobilesecurityservice/status_test.go
@@ -61,9 +61,8 @@ func TestReconcileMobileSecurityService_updateStatus(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			objs := []runtime.Object{tt.fields.instance}
 
-			r := buildReconcileWithFakeClientWithMocks(objs, t)
+			r := buildReconcileWithFakeClientWithMocks(tt.fields.objs, t)
 
 			reqLogger := log.WithValues("Request.Namespace", tt.args.request.Namespace, "Request.Name", tt.args.request.Name)
 

--- a/pkg/controller/mobilesecurityservicedb/controller_test.go
+++ b/pkg/controller/mobilesecurityservicedb/controller_test.go
@@ -1,0 +1,333 @@
+package mobilesecurityservicedb
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcileMobileSecurityServiceDB_update(t *testing.T) {
+	type fields struct {
+		createdInstance  *v1alpha1.MobileSecurityServiceDB
+		instanceToUpdate *v1alpha1.MobileSecurityServiceDB
+		scheme           *runtime.Scheme
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "should successfully update the instance",
+			fields: fields{
+				createdInstance:  &instanceOne,
+				instanceToUpdate: &instanceOne,
+			},
+			wantErr: false,
+		},
+		{
+			name: "should give an error when the namespace is not found",
+			fields: fields{
+				createdInstance:  &instanceOne,
+				instanceToUpdate: &instanceTwo,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			objs := []runtime.Object{tt.fields.createdInstance}
+
+			r := newReconcilerWithFakeClient(objs)
+
+			reqLogger := log.WithValues("Request.Namespace", tt.fields.instanceToUpdate.Namespace, "Request.Name", tt.fields.createdInstance.Name)
+
+			err := r.update(tt.fields.instanceToUpdate, reqLogger)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMobileSecurityServiceDB.update() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestReconcileMobileSecurityServiceDB_create(t *testing.T) {
+	type fields struct {
+		scheme *runtime.Scheme
+	}
+	type args struct {
+		instance        *mobilesecurityservicev1alpha1.MobileSecurityServiceDB
+		serviceInstance *mobilesecurityservicev1alpha1.MobileSecurityService
+		kind            string
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		wantErr   bool
+		wantPanic bool
+	}{
+		{
+			name: "should create and return a new deployment",
+			fields: fields{
+				scheme.Scheme,
+			},
+			args: args{
+				instance:        &instanceOne,
+				serviceInstance: &serviceInstance,
+				kind:            DEEPLOYMENT,
+			},
+			wantErr: false,
+		},
+		{
+			name: "should fail to create an unknown type",
+			fields: fields{
+				scheme.Scheme,
+			},
+			args: args{
+				instance:        &instanceOne,
+				serviceInstance: &serviceInstance,
+				kind:            "UNKNOWN",
+			},
+			wantErr:   false,
+			wantPanic: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			objs := []runtime.Object{tt.args.instance}
+
+			r := newReconcilerWithFakeClient(objs)
+
+			reqLogger := log.WithValues("Request.Namespace", tt.args.instance.Namespace, "Request.Name", tt.args.instance.Name)
+
+			defer func() {
+				r := recover()
+				if (r != nil) != tt.wantPanic {
+					t.Errorf("ReconcileMobileSecurityServiceDB.create() recover = %v, wantPanic = %v", r, tt.wantPanic)
+				}
+			}()
+
+			err := r.create(tt.args.instance, tt.args.serviceInstance, tt.args.kind, reqLogger)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMobileSecurityServiceDB.create() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestReconcileMobileSecurityServiceDB_buildFactory(t *testing.T) {
+	type fields struct {
+		scheme *runtime.Scheme
+	}
+	type args struct {
+		instance        *mobilesecurityservicev1alpha1.MobileSecurityServiceDB
+		serviceInstance *mobilesecurityservicev1alpha1.MobileSecurityService
+		kind            string
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		want      reflect.Type
+		wantPanic bool
+	}{
+		{
+			name: "should create a Deployment",
+			fields: fields{
+				scheme: scheme.Scheme,
+			},
+			args: args{
+				instance:        &instanceOne,
+				serviceInstance: &serviceInstance,
+				kind:            DEEPLOYMENT,
+			},
+			want: reflect.TypeOf(&v1beta1.Deployment{}),
+		},
+		{
+			name: "should create a Persistent Volume Claim",
+			fields: fields{
+				scheme: scheme.Scheme,
+			},
+			args: args{
+				instance:        &instanceOne,
+				serviceInstance: &serviceInstance,
+				kind:            PVC,
+			},
+			want: reflect.TypeOf(&corev1.PersistentVolumeClaim{}),
+		},
+		{
+			name: "should create a Service",
+			fields: fields{
+				scheme: scheme.Scheme,
+			},
+			args: args{
+				instance:        &instanceOne,
+				serviceInstance: &serviceInstance,
+				kind:            SERVICE,
+			},
+			want: reflect.TypeOf(&corev1.Service{}),
+		},
+		{
+			name: "Should panic when trying to create unrecognized object type",
+			fields: fields{
+				scheme: scheme.Scheme,
+			},
+			args: args{
+				instance:        &instanceOne,
+				serviceInstance: &serviceInstance,
+				kind:            "UNDEFINED",
+			},
+			wantPanic: true,
+			want:      nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			objs := []runtime.Object{tt.args.instance}
+
+			r := newReconcilerWithFakeClient(objs)
+
+			reqLogger := log.WithValues("Request.Namespace", tt.args.instance.Namespace, "Request.Name", tt.args.instance.Name)
+
+			// testing if the panic() function is executed
+			defer func() {
+				r := recover()
+				if (r != nil) != tt.wantPanic {
+					t.Errorf("ReconcileMobileSecurityServiceDB.buildFactory() recover = %v, wantPanic = %v", r, tt.wantPanic)
+				}
+			}()
+
+			got := r.buildFactory(tt.args.instance, tt.args.serviceInstance, tt.args.kind, reqLogger)
+
+			if gotType := reflect.TypeOf(got); !reflect.DeepEqual(gotType, tt.want) {
+				t.Errorf("ReconcileMobileSecurityServiceDB.buildFactory() = %v, want %v", gotType, tt.want)
+			}
+		})
+	}
+}
+
+func TestReconcileMobileSecurityServiceDB_Reconcile(t *testing.T) {
+
+	// objects to track in the fake client
+	objs := []runtime.Object{
+		&instanceOne,
+	}
+
+	r := newReconcilerWithFakeClient(objs)
+
+	// mock request to simulate Reconcile() being called on an event for a watched resource
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      instanceOne.Name,
+			Namespace: instanceOne.Namespace,
+		},
+	}
+
+	res, err := r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	deployment := &v1beta1.Deployment{}
+	err = r.client.Get(context.TODO(), req.NamespacedName, deployment)
+	if err != nil {
+		t.Fatalf("get deployment: (%v)", err)
+	}
+
+	if !res.Requeue {
+		t.Error("reconcile did not requeue request as expected")
+	}
+
+	res, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	service := &corev1.Service{}
+	err = r.client.Get(context.TODO(), req.NamespacedName, service)
+	if err != nil {
+		t.Fatalf("get service: (%v)", err)
+	}
+
+	if res.Requeue {
+		t.Error("reconcile did not requeue request as expected")
+	}
+
+	res, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	err = r.client.Get(context.TODO(), req.NamespacedName, pvc)
+	if err != nil {
+		t.Fatalf("get pvc: (%v)", err)
+	}
+
+	if res.Requeue {
+		t.Error("reconcile did not requeue request as expected")
+	}
+
+	res, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	if res.Requeue {
+		t.Error("did not expect request to requeue")
+	}
+}
+
+func TestReconcileMobileSecurityServiceDB_Reconcile_NotFound(t *testing.T) {
+
+	// objects to track in the fake client
+	objs := []runtime.Object{
+		&instanceOne,
+	}
+
+	r := newReconcilerWithFakeClient(objs)
+
+	// mock request to simulate Reconcile() being called on an event for a watched resource
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      instanceOne.Name,
+			Namespace: "unknown",
+		},
+	}
+
+	res, err := r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile: (%v)", err)
+	}
+
+	if res.Requeue {
+		t.Fatalf("did not expected reconcile to requeue.")
+	}
+}
+
+// Creates a new reconciler with a fake client
+func newReconcilerWithFakeClient(objs []runtime.Object) *ReconcileMobileSecurityServiceDB {
+	s := scheme.Scheme
+
+	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.MobileSecurityServiceDB{})
+
+	// create a fake client to mock API calls
+	cl := fake.NewFakeClient(objs...)
+	// create a ReconcileMobileSecurityService object with the scheme and fake client
+	return &ReconcileMobileSecurityServiceDB{client: cl, scheme: s}
+}

--- a/pkg/controller/mobilesecurityservicedb/status_test.go
+++ b/pkg/controller/mobilesecurityservicedb/status_test.go
@@ -1,0 +1,157 @@
+package mobilesecurityservicedb
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcileMobileSecurityServiceDB_updateDBStatus(t *testing.T) {
+	type fields struct {
+		objs   []runtime.Object
+		scheme *runtime.Scheme
+	}
+	type args struct {
+		deploymentStatus *v1beta1.Deployment
+		serviceStatus    *corev1.Service
+		pvcStatus        *corev1.PersistentVolumeClaim
+		request          reconcile.Request
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "should return an error when no name found",
+			fields: fields{
+				objs:   []runtime.Object{&instanceOne},
+				scheme: scheme.Scheme,
+			},
+			args: args{
+				request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      instanceOne.Name,
+						Namespace: instanceOne.Namespace,
+					},
+				},
+				deploymentStatus: &v1beta1.Deployment{},
+				serviceStatus:    &corev1.Service{},
+				pvcStatus:        &corev1.PersistentVolumeClaim{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "should update status",
+			fields: fields{
+				objs:   []runtime.Object{&instanceOne},
+				scheme: scheme.Scheme,
+			},
+			args: args{
+				request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      instanceOne.Name,
+						Namespace: instanceOne.Namespace,
+					},
+				},
+				deploymentStatus: &v1beta1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "DeploymentName",
+					},
+				},
+				serviceStatus: &corev1.Service{},
+				pvcStatus:     &corev1.PersistentVolumeClaim{},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			r := newReconcilerWithFakeClient(tt.fields.objs)
+
+			reqLogger := log.WithValues("Request.Namespace", tt.args.request.Namespace, "Request.Name", tt.args.request.Name)
+
+			if err := r.updateDBStatus(reqLogger, tt.args.deploymentStatus, tt.args.serviceStatus, tt.args.pvcStatus, tt.args.request); (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMobileSecurityServiceDB.updateDBStatus() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestReconcileMobileSecurityServiceDB_updateDeploymentStatus(t *testing.T) {
+	type fields struct {
+		scheme *runtime.Scheme
+		objs   []runtime.Object
+	}
+	type args struct {
+		request reconcile.Request
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    reflect.Type
+		wantErr bool
+	}{
+		{
+			name: "Should not find the instance",
+			fields: fields{
+				scheme: scheme.Scheme,
+				objs:   []runtime.Object{&instanceOne},
+			},
+			args: args{
+				request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      instanceTwo.Name,
+						Namespace: instanceTwo.Namespace,
+					},
+				},
+			},
+			wantErr: true,
+			want:    reflect.TypeOf(&v1beta1.Deployment{}),
+		},
+		{
+			name: "Should not find the Deployment",
+			fields: fields{
+				scheme: scheme.Scheme,
+				objs:   []runtime.Object{&instanceOne},
+			},
+			args: args{
+				request: reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      instanceOne.Name,
+						Namespace: instanceOne.Namespace,
+					},
+				},
+			},
+			wantErr: true,
+			want:    reflect.TypeOf(&v1beta1.Deployment{}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			r := newReconcilerWithFakeClient(tt.fields.objs)
+
+			reqLogger := log.WithValues("Request.Namespace", tt.args.request.Namespace, "Request.Name", tt.args.request.Name)
+
+			got, err := r.updateDeploymentStatus(reqLogger, tt.args.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMobileSecurityServiceDB.updateDeploymentStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotType := reflect.TypeOf(got); !reflect.DeepEqual(gotType, tt.want) {
+				t.Errorf("ReconcileMobileSecurityServiceDB.updateDeploymentStatus() = %v, want %v", gotType, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/mobilesecurityservicedb/test_mocks.go
+++ b/pkg/controller/mobilesecurityservicedb/test_mocks.go
@@ -1,0 +1,72 @@
+package mobilesecurityservicedb
+
+import (
+	"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Centralized mock objects for use in tests
+var (
+	instanceOne = v1alpha1.MobileSecurityServiceDB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mobile-security-service-db",
+			Namespace: "mobile-security-service",
+		},
+		Spec: v1alpha1.MobileSecurityServiceDBSpec{
+			Image:                   "centos/postgresql-96-centos7",
+			Size:                    1,
+			ContainerName:           "database",
+			DatabaseNameParam:       "POSTGRESQL_DATABASE",
+			DatabasePasswordParam:   "POSTGRESQL_PASSWORD",
+			DatabaseUserParam:       "POSTGRESQL_USER",
+			DatabasePort:            5432,
+			DatabaseMemoryLimit:     "512Mi",
+			DatabaseMemoryRequest:   "512Mi",
+			DatabaseStorageRequest:  "1Gi",
+			DatabaseName:            "mobile_security_service",
+			DatabasePassword:        "postgres",
+			DatabaseUser:            "postgresql",
+			SkipNamespaceValidation: true,
+		},
+	}
+
+	instanceTwo = v1alpha1.MobileSecurityServiceDB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mobile-security-service-db",
+			Namespace: "mobile-security-service-namespace",
+		},
+		Spec: v1alpha1.MobileSecurityServiceDBSpec{
+			Image:                   "centos/postgresql-96-centos7",
+			Size:                    1,
+			ContainerName:           "database",
+			DatabaseNameParam:       "POSTGRESQL_DATABASE",
+			DatabasePasswordParam:   "POSTGRESQL_PASSWORD",
+			DatabaseUserParam:       "POSTGRESQL_USER",
+			DatabasePort:            5432,
+			DatabaseMemoryLimit:     "512Mi",
+			DatabaseMemoryRequest:   "512Mi",
+			DatabaseStorageRequest:  "1Gi",
+			DatabaseName:            "mobile_security_service",
+			DatabasePassword:        "postgres",
+			DatabaseUser:            "postgresql",
+			SkipNamespaceValidation: true,
+		},
+	}
+
+	serviceInstance = v1alpha1.MobileSecurityService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mobile-security-service-app",
+			Namespace: "mobile-security-service",
+		},
+		Spec: mobilesecurityservicev1alpha1.MobileSecurityServiceSpec{
+			Size:                    1,
+			MemoryLimit:             "512Mi",
+			MemoryRequest:           "512Mi",
+			ClusterProtocol:         "http",
+			ConfigMapName:           "mss-config",
+			RouteName:               "mss-route",
+			SkipNamespaceValidation: true,
+		},
+	}
+)


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-8952

## What

Added unit tests to cover the `mobilesecurityservicedb` package. Coverage for this package is at 73%.

## Why

Unit tests ensure that the code is fully tested and work as expected.

## How

1. Referred to Operator SDK [documentation](https://github.com/operator-framework/operator-sdk/blob/master/doc/user/unit-testing.md)
2. Referred to [Operator SDK samples](https://github.com/operator-framework/operator-sdk-samples).

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Run `make test`
2. Do the tests pass?
3. Confirm that the CircleCI build is passing: https://circleci.com/gh/aerogear/mobile-security-service-operator.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
