### PR TITLE
Ag 8951 controller tests

### DIFF
--- a/pkg/controller/mobilesecurityserviceapp/controller_test.go
+++ b/pkg/controller/mobilesecurityserviceapp/controller_test.go
@@ -1,0 +1,191 @@
+package mobilesecurityserviceapp
+
+import (
+	errs "errors"
+	"reflect"
+	"testing"
+
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"k8s.io/client-go/kubernetes/scheme"
+
+)
+
+var (
+	instance = mobilesecurityservicev1alpha1.MobileSecurityServiceApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mobile-security-service",
+			Namespace: "mobile-security-service",
+		},
+		Spec: mobilesecurityservicev1alpha1.MobileSecurityServiceAppSpec{
+			AppName: "test-app",
+			AppId:   "test-app-id",
+		},
+
+	}
+)
+
+func TestReconcileMobileSecurityServiceApp_create(t *testing.T) {
+	type fields struct {
+		client client.Client
+		scheme *runtime.Scheme
+	}
+	type args struct {
+		instance   *mobilesecurityservicev1alpha1.MobileSecurityServiceApp
+		kind       string
+		serviceURL string
+		// reqLogger  logr.Logger
+		request    reconcile.Request
+		err					error
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    reconcile.Result
+		wantErr bool
+		wantPanic bool
+	}{
+		{
+			name: "should return a configmap",
+			fields: fields{
+				scheme: scheme.Scheme,
+			},
+			args: args{
+				instance: &instance,
+				kind:     CONFIGMAP,
+				err:      errors.NewInternalError(errs.New("Internal Server Error")),
+			},
+			want:    reconcile.Result{Requeue: true},
+			wantErr: false,
+		},
+		{
+			name: "should return an error when type other than CONFIGMAP specified",
+			fields: fields{
+				scheme: scheme.Scheme,
+			},
+			args: args{
+				instance: &instance,
+				kind:     "WRONG_KIND",
+				err:      errors.NewInternalError(errs.New("Internal Server Error")),
+			},
+			want:    reconcile.Result{},
+			wantErr: true,
+			wantPanic: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			objs := []runtime.Object{tt.args.instance}
+
+			tt.fields.scheme.AddKnownTypes(mobilesecurityservicev1alpha1.SchemeGroupVersion, tt.args.instance)
+
+			cl := fake.NewFakeClient(objs...)
+
+			r := &ReconcileMobileSecurityServiceApp{
+				client: cl,
+				scheme: tt.fields.scheme,
+			}
+
+			reqLogger := log.WithValues("Request.Namespace", tt.args.instance.Namespace, "Request.Name", tt.args.instance.Name)
+
+			// testing if the panic() function is executed
+			defer func() {
+				r := recover()
+				if (r != nil) != tt.wantPanic {
+					t.Errorf("ReconcileMobileSecurityService.buildFactory() recover = %v, wantPanic = %v", r, tt.wantPanic)
+				}
+			}()
+
+			got, err := r.create(tt.args.instance, tt.args.kind, tt.args.serviceURL, reqLogger, tt.args.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMobileSecurityServiceApp.create() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReconcileMobileSecurityServiceApp.create() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReconcileMobileSecurityServiceApp_buildFactory(t *testing.T) {
+	type fields struct {
+		client client.Client
+		scheme *runtime.Scheme
+	}
+	type args struct {
+		reqLogger  logr.Logger
+		instance   *mobilesecurityservicev1alpha1.MobileSecurityServiceApp
+		kind       string
+		serviceURL string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    runtime.Object
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReconcileMobileSecurityServiceApp{
+				client: tt.fields.client,
+				scheme: tt.fields.scheme,
+			}
+			got, err := r.buildFactory(tt.args.reqLogger, tt.args.instance, tt.args.kind, tt.args.serviceURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMobileSecurityServiceApp.buildFactory() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReconcileMobileSecurityServiceApp.buildFactory() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReconcileMobileSecurityServiceApp_Reconcile(t *testing.T) {
+	type fields struct {
+		client client.Client
+		scheme *runtime.Scheme
+	}
+	type args struct {
+		request reconcile.Request
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    reconcile.Result
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReconcileMobileSecurityServiceApp{
+				client: tt.fields.client,
+				scheme: tt.fields.scheme,
+			}
+			got, err := r.Reconcile(tt.args.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMobileSecurityServiceApp.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReconcileMobileSecurityServiceApp.Reconcile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation
AEROGEAR-8951 

## What
Add test coverage for create & buildfactory methods in app controller (tests for reconcile in another PR)

## Why
Add test coverage

## How
Add test coverage for create & buildfactory methods in app controller

## Verification Steps
- confirm tests run locally (`GOCACHE=off go test -cover github.com/aerogear/mobile-security-service-operator/pkg/controller/mobilesecurityserviceapp -v`)
- confirm tests are passing in CI in this PR

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task

## Additional Notes

 
