### PR TITLE
Ag 8951 controller reconcile

### DIFF
--- a/pkg/controller/mobilesecurityserviceapp/controller.go
+++ b/pkg/controller/mobilesecurityserviceapp/controller.go
@@ -125,7 +125,7 @@ func (r *ReconcileMobileSecurityServiceApp) Reconcile(request reconcile.Request)
 	// We should not checked if the namespace is valid or not. It is an workaround since currently is not possible watch/cache a List of Namespaces
 	// The impl to allow do it is done and merged in the master branch of the lib but not released in an stable version. It should be removed when this feature be impl.
 	// See the PR which we are working on to update the deps and have this feature: https://github.com/operator-framework/operator-sdk/pull/1388
-	if isValidNamespace, err := utils.IsValidAppNamespace(request.Namespace); err != nil || isValidNamespace == false {
+	if isValidNamespace, err := utils.IsValidAppNamespace(request.Namespace, instance.Spec.SkipNamespaceValidation); err != nil || isValidNamespace == false {
 		// Stop reconcile
 		envVar, _ := utils.GetAppNamespaces()
 		reqLogger.Error(err, "Unable to reconcile Mobile Security Service App", "Request.Namespace", request.Namespace, "isValidNamespace", isValidNamespace, "EnvVar.APP_NAMESPACES", envVar)
@@ -212,7 +212,6 @@ func (r *ReconcileMobileSecurityServiceApp) Reconcile(request reconcile.Request)
 	if err := service.CreateAppByRestAPI(serviceAPI, newApp, reqLogger); err != nil {
 		return reconcile.Result{}, err
 	}
-	return reconcile.Result{Requeue: false}, nil
 
 	//Update status for SDKConfigMap
 	SDKConfigMapStatus, err := r.updateSDKConfigMapStatus(reqLogger, request)
@@ -225,5 +224,5 @@ func (r *ReconcileMobileSecurityServiceApp) Reconcile(request reconcile.Request)
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{Requeue: false}, nil
 }

--- a/pkg/controller/mobilesecurityserviceapp/controller_test.go
+++ b/pkg/controller/mobilesecurityserviceapp/controller_test.go
@@ -6,16 +6,30 @@ import (
 	"testing"
 
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	"github.com/aerogear/mobile-security-service-operator/pkg/utils"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	routev1 "github.com/openshift/api/route/v1"
+
 	corev1 "k8s.io/api/core/v1"
+	// "k8s.io/api/extensions/v1beta1"
+
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 
+	"github.com/aerogear/mobile-security-service-operator/pkg/models"
+
+	"github.com/aerogear/mobile-security-service-operator/pkg/service"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"k8s.io/client-go/kubernetes/scheme"
-
 )
 
 var (
@@ -25,12 +39,54 @@ var (
 			Namespace: "mobile-security-service",
 		},
 		Spec: mobilesecurityservicev1alpha1.MobileSecurityServiceAppSpec{
+			AppName:                 "test-app",
+			AppId:                   "test-app-id",
+			SkipNamespaceValidation: true,
+		},
+	}
+
+	instanceTwo = mobilesecurityservicev1alpha1.MobileSecurityServiceApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mobile-security-service",
+			Namespace: "mobile-security-service-2",
+		},
+		Spec: mobilesecurityservicev1alpha1.MobileSecurityServiceAppSpec{
 			AppName: "test-app",
 			AppId:   "test-app-id",
 		},
+	}
 
+	mssInstance = mobilesecurityservicev1alpha1.MobileSecurityService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mobile-security-service",
+			Namespace: "mobile-security-service-operator",
+		},
+		Spec: mobilesecurityservicev1alpha1.MobileSecurityServiceSpec{
+			Size:                    1,
+			MemoryLimit:             "512Mi",
+			MemoryRequest:           "512Mi",
+			ClusterProtocol:         "http",
+			ConfigMapName:           "mss-config",
+			Port:                    1234,
+			RouteName:               "mss-route",
+			SkipNamespaceValidation: true,
+		},
+	}
+
+	route = routev1.Route{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: "route.openshift.io/v1",
+			Kind:       "Route",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      utils.GetRouteName(&mssInstance),
+			Namespace: mssInstance.Namespace,
+			Labels:    getAppLabels(mssInstance.Name),
+		},
 	}
 )
+
+const envVar = "envVar"
 
 func TestReconcileMobileSecurityServiceApp_create(t *testing.T) {
 	type fields struct {
@@ -42,15 +98,15 @@ func TestReconcileMobileSecurityServiceApp_create(t *testing.T) {
 		kind       string
 		serviceURL string
 		// reqLogger  logr.Logger
-		request    reconcile.Request
-		err					error
+		request reconcile.Request
+		err     error
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    reconcile.Result
-		wantErr bool
+		name      string
+		fields    fields
+		args      args
+		want      reconcile.Result
+		wantErr   bool
 		wantPanic bool
 	}{
 		{
@@ -76,8 +132,8 @@ func TestReconcileMobileSecurityServiceApp_create(t *testing.T) {
 				kind:     "WRONG_KIND",
 				err:      errors.NewInternalError(errs.New("Internal Server Error")),
 			},
-			want:    reconcile.Result{},
-			wantErr: true,
+			want:      reconcile.Result{},
+			wantErr:   true,
 			wantPanic: true,
 		},
 	}
@@ -142,8 +198,8 @@ func TestReconcileMobileSecurityServiceApp_buildFactory(t *testing.T) {
 			},
 			want: reflect.TypeOf(&corev1.ConfigMap{}),
 			args: args{
-				instance: &instance,
-				kind:     CONFIGMAP,
+				instance:   &instance,
+				kind:       CONFIGMAP,
 				serviceURL: "service-url",
 			},
 		},
@@ -153,8 +209,8 @@ func TestReconcileMobileSecurityServiceApp_buildFactory(t *testing.T) {
 				scheme: scheme.Scheme,
 			},
 			args: args{
-				instance: &instance,
-				kind:     "UNDEFINED",
+				instance:   &instance,
+				kind:       "UNDEFINED",
 				serviceURL: "service-url",
 			},
 			wantPanic: true,
@@ -198,36 +254,97 @@ func TestReconcileMobileSecurityServiceApp_buildFactory(t *testing.T) {
 }
 
 func TestReconcileMobileSecurityServiceApp_Reconcile(t *testing.T) {
-	type fields struct {
-		client client.Client
-		scheme *runtime.Scheme
+	// objects to track in the fake client
+	objs := []runtime.Object{
+		&instance,
+		&instanceTwo,
+		&mssInstance,
+		&route,
 	}
-	type args struct {
-		request reconcile.Request
+
+	r := getReconciler(objs)
+
+	// mock request to simulate Reconcile() being called on an event for a watched resource
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      instance.Name,
+			Namespace: instance.Namespace,
+		},
 	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    reconcile.Result
-		wantErr bool
-	}{
-		// TODO: Add test cases.
+
+	// Initial call to reconciler - should fail on config map, create it, and requeue request
+	res, err := r.Reconcile(req)
+	if !res.Requeue {
+		t.Error("reconcile did not requeue request as expected")
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := &ReconcileMobileSecurityServiceApp{
-				client: tt.fields.client,
-				scheme: tt.fields.scheme,
-			}
-			got, err := r.Reconcile(tt.args.request)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ReconcileMobileSecurityServiceApp.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ReconcileMobileSecurityServiceApp.Reconcile() = %v, want %v", got, tt.want)
-			}
-		})
+
+	// check configmap created
+	reqLogger := log.WithValues("Request.Namespace", &req.NamespacedName.Namespace, "Request.Name", &req.NamespacedName.Name)
+	_, err = r.fetchSDKConfigMap(reqLogger, &instance)
+	// configmap was not created properly
+	if err != nil {
+		// configmap was not created properly
+		t.Fatalf("get configmap: (%v)", err)
 	}
+
+	// mock `fetchBindAppRestServiceByAppID` restful call
+	fetchBindAppRestServiceByAppID = func(serviceURL string, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp, reqLogger logr.Logger) (*models.App, error) {
+		app := models.App{AppName: "test-app", AppID: "test-app-id"}
+		return &app, nil
+	}
+
+	// mock CreateAppByRestAPI
+	service.CreateAppByRestAPI = func(serviceAPI string, app models.App, reqLogger logr.Logger) error {
+		return nil
+	}
+
+	// call reconcile again - configmap should be created
+	res, err = r.Reconcile(req)
+	if res.Requeue {
+		t.Error("reconcile did not requeue request as expected after creating app")
+	}
+
+	// call reconcile again after creating app
+	res, err = r.Reconcile(req)
+
+	SDKConfigMapStatus, err := r.updateSDKConfigMapStatus(reqLogger, req)
+	// configmap was not updated properly
+	if err != nil {
+		// configmap was not updated properly
+		t.Fatalf("update configmap: (%v)", err)
+	}
+
+	// mock updateBindStatus
+	// updateBindStatus = func() error {
+	// 	return nil
+	// }
+
+	// 
+	SDKConfigMapStatus.UID = "1234"
+	err = r.updateBindStatus("http://mobile-security-service-application:1234/api", reqLogger, SDKConfigMapStatus, req)
+	if err != nil {
+		// bindStatus was not updated properly
+		t.Fatalf("update bind status: (%v)", err)
+	}
+
+	if res.Requeue {
+		t.Error("reconcile requeued instead of returning successfully")
+	} 
+}
+
+func getReconciler(objs []runtime.Object) *ReconcileMobileSecurityServiceApp {
+	s := scheme.Scheme
+
+	routev1.AddToScheme(s)
+
+	s.AddKnownTypes(mobilesecurityservicev1alpha1.SchemeGroupVersion, &mobilesecurityservicev1alpha1.MobileSecurityServiceApp{})
+
+	s.AddKnownTypes(mobilesecurityservicev1alpha1.SchemeGroupVersion, &mobilesecurityservicev1alpha1.MobileSecurityService{})
+	s.AddKnownTypes(routev1.SchemeGroupVersion, &routev1.Route{})
+	s.AddKnownTypes(corev1.SchemeGroupVersion, &corev1.ConfigMap{}, &corev1.Service{})
+
+	// create a fake client to mock API calls
+	cl := fake.NewFakeClient(objs...)
+	// create a ReconcileMobileSecurityServiceApp object with the scheme and fake client
+	return &ReconcileMobileSecurityServiceApp{client: cl, scheme: s}
 }

--- a/pkg/controller/mobilesecurityserviceapp/controller_test.go
+++ b/pkg/controller/mobilesecurityserviceapp/controller_test.go
@@ -1,0 +1,191 @@
+package mobilesecurityserviceapp
+
+import (
+	errs "errors"
+	"reflect"
+	"testing"
+
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"k8s.io/client-go/kubernetes/scheme"
+
+)
+
+var (
+	instance = mobilesecurityservicev1alpha1.MobileSecurityServiceApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mobile-security-service",
+			Namespace: "mobile-security-service",
+		},
+		Spec: mobilesecurityservicev1alpha1.MobileSecurityServiceAppSpec{
+			AppName: "test-app",
+			AppId:   "test-app-id",
+		},
+
+	}
+)
+
+func TestReconcileMobileSecurityServiceApp_create(t *testing.T) {
+	type fields struct {
+		client client.Client
+		scheme *runtime.Scheme
+	}
+	type args struct {
+		instance   *mobilesecurityservicev1alpha1.MobileSecurityServiceApp
+		kind       string
+		serviceURL string
+		// reqLogger  logr.Logger
+		request    reconcile.Request
+		err					error
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    reconcile.Result
+		wantErr bool
+		wantPanic bool
+	}{
+		{
+			name: "should return a configmap",
+			fields: fields{
+				scheme: scheme.Scheme,
+			},
+			args: args{
+				instance: &instance,
+				kind:     CONFIGMAP,
+				err:      errors.NewInternalError(errs.New("Internal Server Error")),
+			},
+			want:    reconcile.Result{Requeue: true},
+			wantErr: false,
+		},
+		{
+			name: "should return an error when type other than CONFIGMAP specified",
+			fields: fields{
+				scheme: scheme.Scheme,
+			},
+			args: args{
+				instance: &instance,
+				kind:     "WRONG_KIND",
+				err:      errors.NewInternalError(errs.New("Internal Server Error")),
+			},
+			want:    reconcile.Result{},
+			wantErr: true,
+			wantPanic: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			objs := []runtime.Object{tt.args.instance}
+
+			tt.fields.scheme.AddKnownTypes(mobilesecurityservicev1alpha1.SchemeGroupVersion, tt.args.instance)
+
+			cl := fake.NewFakeClient(objs...)
+
+			r := &ReconcileMobileSecurityServiceApp{
+				client: cl,
+				scheme: tt.fields.scheme,
+			}
+
+			reqLogger := log.WithValues("Request.Namespace", tt.args.instance.Namespace, "Request.Name", tt.args.instance.Name)
+
+			// testing if the panic() function is executed
+			defer func() {
+				r := recover()
+				if (r != nil) != tt.wantPanic {
+					t.Errorf("ReconcileMobileSecurityService.buildFactory() recover = %v, wantPanic = %v", r, tt.wantPanic)
+				}
+			}()
+
+			got, err := r.create(tt.args.instance, tt.args.kind, tt.args.serviceURL, reqLogger, tt.args.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMobileSecurityServiceApp.create() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReconcileMobileSecurityServiceApp.create() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReconcileMobileSecurityServiceApp_buildFactory(t *testing.T) {
+	type fields struct {
+		client client.Client
+		scheme *runtime.Scheme
+	}
+	type args struct {
+		reqLogger  logr.Logger
+		instance   *mobilesecurityservicev1alpha1.MobileSecurityServiceApp
+		kind       string
+		serviceURL string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    runtime.Object
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReconcileMobileSecurityServiceApp{
+				client: tt.fields.client,
+				scheme: tt.fields.scheme,
+			}
+			got, err := r.buildFactory(tt.args.reqLogger, tt.args.instance, tt.args.kind, tt.args.serviceURL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMobileSecurityServiceApp.buildFactory() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReconcileMobileSecurityServiceApp.buildFactory() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReconcileMobileSecurityServiceApp_Reconcile(t *testing.T) {
+	type fields struct {
+		client client.Client
+		scheme *runtime.Scheme
+	}
+	type args struct {
+		request reconcile.Request
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    reconcile.Result
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReconcileMobileSecurityServiceApp{
+				client: tt.fields.client,
+				scheme: tt.fields.scheme,
+			}
+			got, err := r.Reconcile(tt.args.request)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMobileSecurityServiceApp.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReconcileMobileSecurityServiceApp.Reconcile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/mobilesecurityserviceapp/fetches.go
+++ b/pkg/controller/mobilesecurityserviceapp/fetches.go
@@ -30,6 +30,6 @@ func (r *ReconcileMobileSecurityServiceApp) fetchSDKConfigMap(reqLogger logr.Log
 }
 
 //fetchBindAppRestServiceByAppID return app struct from Mobile Security Service Project/REST API or error
-func fetchBindAppRestServiceByAppID(serviceURL string, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp, reqLogger logr.Logger) (*models.App, error) {
+var fetchBindAppRestServiceByAppID = func(serviceURL string, instance *mobilesecurityservicev1alpha1.MobileSecurityServiceApp, reqLogger logr.Logger) (*models.App, error) {
 	return service.GetAppFromServiceByRestApi(serviceURL, instance.Spec.AppId, reqLogger)
 }

--- a/pkg/service/client.go
+++ b/pkg/service/client.go
@@ -39,7 +39,7 @@ func DeleteAppFromServiceByRestAPI(serviceAPI string, id string, reqLogger logr.
 }
 
 //CreateAppByRestAPI create the app object in the service
-func CreateAppByRestAPI(serviceAPI string, app models.App, reqLogger logr.Logger) error {
+var CreateAppByRestAPI = func(serviceAPI string, app models.App, reqLogger logr.Logger) error {
 	reqLogger.Info("Calling Service to POST app", "serviceAPI", serviceAPI, "App", app)
 
 	// Create the object and parse for JSON

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -11,5 +11,6 @@ const ENDPOINT_API = "/api"
 
 //Return REST Service API
 func GetServiceAPIURL(mssInstance *mobilesecurityservicev1alpha1.MobileSecurityService) string {
-	return mssInstance.Spec.ClusterProtocol + "://" + utils.APPLICATION_SERVICE_INSTANCE_NAME + ":" + fmt.Sprint(mssInstance.Spec.Port) + ENDPOINT_API
+	uri := mssInstance.Spec.ClusterProtocol + "://" + utils.APPLICATION_SERVICE_INSTANCE_NAME + ":" + fmt.Sprint(mssInstance.Spec.Port) + ENDPOINT_API
+	return uri
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -45,7 +45,12 @@ func GetAppNamespaces() (string, error) {
 }
 
 // IsValidAppNamespace return true when the namespace informed is declared in the ENV VAR APP_NAMESPACES
-func IsValidAppNamespace(namespace string) (bool, error) {
+func IsValidAppNamespace(namespace string, skipCheck bool) (bool, error) {
+	//FIXME: this check is used to bypass validation of namespace.
+	// This is a workaround and should be removed in the future.
+	if skipCheck {
+		return true, nil
+	}
 	appNamespacesEnvVar, err := GetAppNamespaces()
 	if err != nil {
 		log.Error(err, "Unable to check if is app namespace %s is valid", namespace)
@@ -78,3 +83,15 @@ func IsValidOperatorNamespace(namespace string, skipCheck bool) (bool, error) {
 	err = fmt.Errorf("Invalid Namespace")
 	return false, err
 }
+
+// 
+func getOperatorNamespace(skipCheck bool) (namespace string, err error) {
+	// Returns a hardcoded namespace string for testing purposes
+	// Tests will not run on a cluster to retrieve a namespace value from cluster 
+	if skipCheck {
+		return "mobile-security-service-operator", nil
+	}
+	namespace, err = k8sutil.GetOperatorNamespace()
+	return namespace, err
+}
+


### PR DESCRIPTION
## Motivation
AEROGEAR-8951 

## What
Add test coverage for reconcile() method in app controller

## Why
Add test coverage

## How
Add test coverage for reconcile() method in app controller

## Verification Steps
- confirm tests run locally (`GOCACHE=off go test -cover github.com/aerogear/mobile-security-service-operator/pkg/controller/mobilesecurityserviceapp -v`)
- confirm tests are passing in CI in this PR

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [ ] Finished task

## Additional Notes

 
