### PR TITLE
fix(make): Delete app CRD first (AEROGEAR-9224)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,9 @@ create-all:
 delete-all:
 	@echo Delete Mobile Security Service Operator, Service and namespace ${NAMESPACE}:
 	- kubectl delete -f deploy/service_monitor.yaml
+	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityserviceapp_crd.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
-	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityserviceapp_crd.yaml
 	- kubectl delete -f deploy/cluster_role.yaml
 	- kubectl delete -f deploy/cluster_role_binding.yaml
 	- kubectl delete -f deploy/service_account.yaml


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9224

## What
Remove mobile-security-service-app CRD first

## Why
Removing an app CRD, removes all instances of the CR. Removing an app CR requires the server to be up, so this needs to be deleted afterward.

## Verification Steps
1. Checkout this branch locally
2. Run `make create-all`. Wait for all to come up.
3. Run `make create-app-ns`
4. Run `make create-app`
5. Run `make delete-all`
6. Verify everything gets deleted and it does not get stuck

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
 
