### PR TITLE
feat(status) : Add Status when the CR was applied in an invalid namespace (AEROGEAR-9267)

### DIFF
--- a/pkg/controller/mobilesecurityservice/controller.go
+++ b/pkg/controller/mobilesecurityservice/controller.go
@@ -164,6 +164,12 @@ func (r *ReconcileMobileSecurityService) Reconcile(request reconcile.Request) (r
 		// Stop reconcile
 		operatorNamespace, _ := k8sutil.GetOperatorNamespace()
 		reqLogger.Error(err, "Unable to reconcile Mobile Security Service", "instance.Namespace", instance.Namespace, "isValidNamespace", isValidNamespace, "Operator.Namespace", operatorNamespace)
+
+		//Update status with Invalid Namespace
+		if err := r.updateStatusWithInvalidNamespace(reqLogger, request); err != nil {
+			return reconcile.Result{}, err
+		}
+
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/mobilesecurityservice/status.go
+++ b/pkg/controller/mobilesecurityservice/status.go
@@ -45,6 +45,40 @@ func (r *ReconcileMobileSecurityService) updateStatus(reqLogger logr.Logger, con
 	return nil
 }
 
+// updateBindStatusWithInvalidNamespace returns error when status regards the all required resources could not be updated
+// DEPRECATED
+func (r *ReconcileMobileSecurityService) updateStatusWithInvalidNamespace(reqLogger logr.Logger, request reconcile.Request) error {
+	reqLogger.Info("Updating Bind App Status for the MobileSecurityServiceApp")
+
+	// Get the latest version of CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return err
+	}
+
+	status := "Invalid Namespace"
+
+	//Update Bind CR Status with OK
+	if !reflect.DeepEqual(status, instance.Status.AppStatus) {
+		// Get the latest version of the CR in order to try to avoid errors when try to update the CR
+		instance, err := r.fetchInstance(reqLogger, request)
+		if err != nil {
+			return err
+		}
+
+		// Set the data
+		instance.Status.AppStatus = status
+
+		// Update the CR
+		err = r.client.Status().Update(context.TODO(), instance)
+		if err != nil {
+			reqLogger.Error(err, "Failed to update Status for the MobileSecurityService Bind")
+			return err
+		}
+	}
+	return nil
+}
+
 //updateConfigMapStatus returns error when status regards the ConfigMap resource could not be updated
 func (r *ReconcileMobileSecurityService) updateConfigMapStatus(reqLogger logr.Logger, request reconcile.Request) (*corev1.ConfigMap, error) {
 	reqLogger.Info("Updating ConfigMap Status for the MobileSecurityService")

--- a/pkg/controller/mobilesecurityserviceapp/controller.go
+++ b/pkg/controller/mobilesecurityserviceapp/controller.go
@@ -126,6 +126,12 @@ func (r *ReconcileMobileSecurityServiceApp) Reconcile(request reconcile.Request)
 		// Stop reconcile
 		envVar, _ := utils.GetAppNamespaces()
 		reqLogger.Error(err, "Unable to reconcile Mobile Security Service App", "instance.Namespace", instance.Namespace, "isValidNamespace", isValidNamespace, "EnvVar.APP_NAMESPACES", envVar)
+
+		//Update status with Invalid Namespace
+		if err := r.updateBindStatusWithInvalidNamespace(reqLogger, request); err != nil {
+			return reconcile.Result{}, err
+		}
+
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/mobilesecurityserviceapp/status.go
+++ b/pkg/controller/mobilesecurityserviceapp/status.go
@@ -93,3 +93,37 @@ func (r *ReconcileMobileSecurityServiceApp) updateBindStatus(serviceURL string, 
 	}
 	return nil
 }
+
+// updateBindStatusWithInvalidNamespace returns error when status regards the all required resources could not be updated
+// DEPRECATED
+func (r *ReconcileMobileSecurityServiceApp) updateBindStatusWithInvalidNamespace(reqLogger logr.Logger, request reconcile.Request) error {
+	reqLogger.Info("Updating Bind App Status for the MobileSecurityServiceApp")
+
+	// Get the latest version of CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return err
+	}
+
+	status := "Invalid Namespace"
+
+	//Update Bind CR Status with OK
+	if !reflect.DeepEqual(status, instance.Status.BindStatus) {
+		// Get the latest version of the CR in order to try to avoid errors when try to update the CR
+		instance, err := r.fetchInstance(reqLogger, request)
+		if err != nil {
+			return err
+		}
+
+		// Set the data
+		instance.Status.BindStatus = status
+
+		// Update the CR
+		err = r.client.Status().Update(context.TODO(), instance)
+		if err != nil {
+			reqLogger.Error(err, "Failed to update Status for the MobileSecurityService Bind")
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/mobilesecurityservicedb/controller.go
+++ b/pkg/controller/mobilesecurityservicedb/controller.go
@@ -154,6 +154,12 @@ func (r *ReconcileMobileSecurityServiceDB) Reconcile(request reconcile.Request) 
 	if isValidNamespace, err := utils.IsValidOperatorNamespace(instance.Namespace); err != nil || isValidNamespace == false {
 		// Stop reconcile
 		reqLogger.Error(err, "Unable to reconcile Mobile Security Service Database", "instance.Namespace", instance.Namespace, "isValidNamespace", isValidNamespace, "Operator.Namespace", operatorNamespace)
+
+		//Update status with Invalid Namespace
+		if err := r.updateStatusWithInvalidNamespace(reqLogger, request); err != nil {
+			return reconcile.Result{}, err
+		}
+
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/mobilesecurityservicedb/status.go
+++ b/pkg/controller/mobilesecurityservicedb/status.go
@@ -158,3 +158,37 @@ func (r *ReconcileMobileSecurityServiceDB) updatePvcStatus(reqLogger logr.Logger
 	}
 	return pvcStatus, nil
 }
+
+// updateBindStatusWithInvalidNamespace returns error when status regards the all required resources could not be updated
+// DEPRECATED
+func (r *ReconcileMobileSecurityServiceDB) updateStatusWithInvalidNamespace(reqLogger logr.Logger, request reconcile.Request) error {
+	reqLogger.Info("Updating App Status for the MobileSecurityServiceDB")
+
+	// Get the latest version of CR
+	instance, err := r.fetchInstance(reqLogger, request)
+	if err != nil {
+		return err
+	}
+
+	status := "Invalid Namespace"
+
+	//Update Bind CR Status with OK
+	if !reflect.DeepEqual(status, instance.Status.DatabaseStatus) {
+		// Get the latest version of the CR in order to try to avoid errors when try to update the CR
+		instance, err := r.fetchInstance(reqLogger, request)
+		if err != nil {
+			return err
+		}
+
+		// Set the data
+		instance.Status.DatabaseStatus = status
+
+		// Update the CR
+		err = r.client.Status().Update(context.TODO(), instance)
+		if err != nil {
+			reqLogger.Error(err, "Failed to update Status for the MobileSecurityServiceDB")
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -59,6 +59,7 @@ func GetAppNamespaces() (string, error) {
 }
 
 // IsValidAppNamespace return true when the namespace informed is declared in the ENV VAR APP_NAMESPACES
+// DEPRECATED
 func IsValidAppNamespace(namespace string) (bool, error) {
 	appNamespacesEnvVar, err := GetAppNamespaces()
 	if err != nil {
@@ -87,6 +88,7 @@ func IsValidAppNamespace(namespace string) (bool, error) {
 }
 
 // IsValidOperatorNamespace return true when the namespace informed is declared in the ENV VAR APP_NAMESPACES
+// DEPRECATED
 func IsValidOperatorNamespace(namespace string) (bool, error) {
 	//FIXME: this check is used to bypass validation of namespace.
 	ns, err := k8sutil.GetOperatorNamespace()


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9267

## What
- Add Invalid status

## Why
-Make clear that the namespace is invalid

## Verification Steps
Use the image:   docker.io/cmacedo/mobile-security-service-operator:AEROGEAR-9267
1. Install the oper
2. create an app in a namespace that is not valid and check the Status of this resource
3. try to create the MSS in an invalid namespace and check the status of this resource
4. try to create the DB in an invalid namespace and check the status of this resource

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [ ] Finished task
- [ ] TODO

## Additional Notes

 
