### PR TITLE
tests(serviceapp): adds validations.go coverage (AEROGEAR-8951)

### DIFF
--- a/pkg/controller/mobilesecurityserviceapp/mocks_test.go
+++ b/pkg/controller/mobilesecurityserviceapp/mocks_test.go
@@ -21,6 +21,28 @@ var (
 		},
 	}
 
+	instanceNoAppName = mobilesecurityservicev1alpha1.MobileSecurityServiceApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mobile-security-service",
+			Namespace: "mobile-security-service",
+		},
+		Spec: mobilesecurityservicev1alpha1.MobileSecurityServiceAppSpec{
+			AppName: "",
+			AppId:   "test-app-id",
+		},
+	}
+
+	instanceNoAppId = mobilesecurityservicev1alpha1.MobileSecurityServiceApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mobile-security-service",
+			Namespace: "mobile-security-service",
+		},
+		Spec: mobilesecurityservicev1alpha1.MobileSecurityServiceAppSpec{
+			AppName: "test-app",
+			AppId:   "",
+		},
+	}
+
 	instanceInvalidName = mobilesecurityservicev1alpha1.MobileSecurityServiceApp{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "invalid",

--- a/pkg/controller/mobilesecurityserviceapp/status_test.go
+++ b/pkg/controller/mobilesecurityserviceapp/status_test.go
@@ -1,0 +1,54 @@
+package mobilesecurityserviceapp
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+
+)
+
+func TestReconcileMobileSecurityServiceApp_updateBindStatusWithInvalidNamespace(t *testing.T) {
+	type args struct {
+		instance        *mobilesecurityservicev1alpha1.MobileSecurityServiceApp
+		}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "should return without an error when updating status",
+			args: args{
+				instance: 	&instance,
+			},
+			wantErr:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			objs := []runtime.Object{
+				tt.args.instance,
+			}
+
+			r := buildReconcileWithFakeClientWithMocks(objs, t)
+
+			reqLogger := log.WithValues("Request.Namespace", tt.args.instance.Namespace, "Request.Name", tt.args.instance.Name)
+
+			// mock request to simulate Reconcile() being called on an event for a watched resource
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      instance.Name,
+					Namespace: instance.Namespace,
+				},
+			}
+
+			if err := r.updateBindStatusWithInvalidNamespace(reqLogger, req); (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileMobileSecurityServiceApp.updateBindStatusWithInvalidNamespace() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/controller/mobilesecurityserviceapp/validations.go
+++ b/pkg/controller/mobilesecurityserviceapp/validations.go
@@ -13,8 +13,8 @@ func hasMandatorySpecs(instance *mobilesecurityservicev1alpha1.MobileSecuritySer
 		return false
 	}
 
-	//Check if the appId was added in the CR
-	if len(instance.Spec.AppId) < 1 {
+	//Check if the appName was added in the CR
+	if len(instance.Spec.AppName) < 1 {
 		reqLogger.Info("AppName was not found. Check the App CR configuration.")
 		return false
 	}

--- a/pkg/controller/mobilesecurityserviceapp/validations_test.go
+++ b/pkg/controller/mobilesecurityserviceapp/validations_test.go
@@ -1,0 +1,53 @@
+package mobilesecurityserviceapp
+
+import (
+	"testing"
+
+	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"
+)
+
+func Test_hasMandatorySpecs(t *testing.T) {
+	type args struct {
+		instance        *mobilesecurityservicev1alpha1.MobileSecurityServiceApp
+		serviceInstance *mobilesecurityservicev1alpha1.MobileSecurityService
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "should return true when instance has an AppId and AppName",
+			args: args{
+				instance:     		&instance,
+				serviceInstance:  	&mssInstance,
+			},
+			want:    true,
+		},
+		{
+			name: "should return false when instance has no AppId",
+			args: args{
+				instance:     		&instanceNoAppName,
+				serviceInstance:  	&mssInstance,
+			},
+			want:    false,
+		},
+		{
+			name: "should return false when instance has no AppName",
+			args: args{
+				instance:     		&instanceNoAppId,
+				serviceInstance:  	&mssInstance,
+			},
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqLogger := log.WithValues("Request.Namespace", &instance.Namespace, "Request.Name", &instance.Name)
+
+			if got := hasMandatorySpecs(tt.args.instance, tt.args.serviceInstance, reqLogger); got != tt.want {
+				t.Errorf("hasMandatorySpecs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation
AEROGEAR-8951 

## What
Add test coverage for gaps in serviceapp pkg

## Why
Add test coverage

## How
Add test coverage for gaps in serviceapp pkg

## Verification Steps

Confirm tests complete successfully:
- confirm tests run locally (`GOCACHE=off go test -cover github.com/aerogear/mobile-security-service-operator/pkg/controller/mobilesecurityserviceapp -v`)
- confirm tests are passing in CI in this PR

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [ ] Finished task

## Additional Notes

 
