### PR TITLE
feat(alerts): Add Alerts be used by the integr8ly project(INTLY-1456)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,6 @@ create-all:
 .PHONY: delete-all
 delete-all:
 	@echo Delete Mobile Security Service Operator, Service and namespace ${NAMESPACE}:
-	- kubectl delete -f deploy/service_monitor.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityserviceapp_crd.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
 	- kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
@@ -98,9 +97,6 @@ delete-all:
 create-oper:
 	@echo Create Mobile Security Service Operator:
 	- oc new-project ${NAMESPACE}
-	- kubectl label namespace ${NAMESPACE} monitoring-key=middleware
-	- kubectl create -f deploy/service_monitor.yaml
-	- kubectl create -f deploy/operator_service.yaml -n ${NAMESPACE}
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_crd.yaml
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_crd.yaml
 	- kubectl create -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityserviceapp_crd.yaml

--- a/README.adoc
+++ b/README.adoc
@@ -142,21 +142,41 @@ $ make delete-all
 
 == Configuration and Options
 
-=== Metrics
+=== Monitoring for the Integr8ly project
 
 The application-monitoring stack provisioned by the
-https://github.com/integr8ly/application-monitoring-operator[application-monitoring-operator]
-can be used to gather metrics from the operator here.  Once you have
-provisioned that (or the ServiceMonitor CRD at a minimum), it is configured by default with `make create-all` 
-you can run the following commands to configure it manually:
+https://github.com/integr8ly/application-monitoring-operator[application-monitoring-operator] on https://github.com/integr8ly[Integr8ly]
+can be used to gather metrics from the operator. These metrics can be used by Integr8ly's application monitoring to generate  Prometheus metrics, AlertManager alerts and a Grafana dashboard 
+You can run the following commands to install it manually:
 
 [source,shell]
 ----
+# Installation of ServiceMonitor
 kubectl label namespace mobile-security-service monitoring-key=middleware
-kubectl create -f deploy/service_monitor.yaml
+kubectl create -f deploy/service_monitor.yaml namespace mobile-security-service
 kubectl create -f deploy/operator_service.yaml namespace mobile-security-service
+
+# Add AlertManager rules to prometheus
+kubectl create -f deploy/prometheus-rule.yaml namespace mobile-security-service
+
+# Add Grafana dashboard 
+kubectl create -f deploy/grafana-dashboard.yaml namespace mobile-security-service
 ----
 
+As all resource are tied to the namespace mobile-security-service removing this project will remove the above resources however if you wish to remove manually 
+
+[source,shell]
+----
+# Delete ServiceMonitor
+kubectl delete -f deploy/service_monitor.yaml namespace mobile-security-service
+kubectl delete -f deploy/operator_service.yaml namespace mobile-security-service
+
+# Delete AlertManager rules to prometheus
+kubectl delete -f deploy/prometheus-rule.yaml namespace mobile-security-service
+
+# Delete Grafana dashboard 
+kubectl delete -f deploy/grafana-dashboard.yaml namespace mobile-security-service
+----
 
 === Oauth Configuration
 

--- a/deploy/prometheus-rule.yaml
+++ b/deploy/prometheus-rule.yaml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: middleware
+    prometheus: application-monitoring
+    role: alert-rules
+  name: application-monitoring
+  namespace: [[ .Namespace ]]
+spec:
+  selector:
+    matchLabels:
+      name: mobile-security-service-operator
+  groups:
+    - name: general.rules
+      rules:
+      - alert: MobileSecurityServiceInstanceDown
+        expr: absent(up{job="mobile-security-service-operator"} == 1)
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          description: "The mobile-security-service-operator has been down for more than 5 minutes. "
+          summary: "The mobile-security-service-operator is down. For more information see on the MMS operator https://github.com/aerogear/mobile-security-service-operator"
+      - alert: MobileSecurityServicePodcount
+        annotations:
+          description: The Pod count for the mobile-security-service has changed in the last 5 minutes.
+          summary: Pod count for namespace mobile-security-service is {{ printf "%.0f" $value }}. Expected exactly 3 pods. For more information see on the MMS operator https://github.com/aerogear/mobile-security-service-operator"
+        expr: |
+          (1-absent(kube_pod_status_ready{condition="true", namespace="mobile-security-service"})) or sum(kube_pod_status_ready{condition="true", namespace="mobile-security-service"}) != 3
+        for: 5m
+        labels:
+          severity: critical


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-1456

## What
adds Alerts to be used in Integr8ly monitoring

## Why
Requirement for Integr8ly

## How
yaml file with a custom resource and update docs. 

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. log on to this cluster https://master.waterford-9fb3.openshiftworkshop.com, credentials can be found on this [doc](https://docs.google.com/document/d/1EX9M9aiJFDJ61HAHtOi305OsNzbKX2EQXtRsf3EWO58)
2. Open the [Prometheus Alerts](https://prometheus-route-middleware-monitoring.apps.waterford-9fb3.openshiftworkshop.com/alerts) and check for the following alerts
![image](https://user-images.githubusercontent.com/16667688/58559975-1d132580-821c-11e9-8320-d052854ec0b7.png)
3. In Openshift console go to the mobile-security-service project and scale down the operator pod.
4. Wait 5 minutes and check the Prometheus Alerts [page](https://prometheus-route-middleware-monitoring.apps.waterford-9fb3.openshiftworkshop.com/alerts) again you will see the alert change to red. 
5. Check AlertManager to see if the Alert has been triggered on this [page](https://alertmanager-route-middleware-monitoring.apps.waterford-9fb3.openshiftworkshop.com/#/alerts) 

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 
