### PR TITLE
fix(namespace) : Remove fixed namespace from the YAML files and add an explanation in the README over how to setup the CusterRole and the operator to work in another namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,8 @@ delete-all:
 	- kubectl delete -f deploy/cluster_role_binding.yaml
 	- kubectl delete -f deploy/service_account.yaml
 	- kubectl delete -f deploy/operator.yaml
+	@echo Call command to uninstall the Monitor Service in the case of it be installed:
+	- make uninstall-service-monitor
 	- kubectl delete namespace ${NAMESPACE}
 
 .PHONY: create-oper
@@ -148,6 +150,25 @@ delete-service-only:
 delete-db-only:
 	@echo Deleting Mobile Security Service Database only:
 	kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
+
+.PHONY: install-service-monitor
+install-service-monitor:
+	@echo Installing service monitor for integr8ly in ${NAMESPACE} :
+	- oc new-project ${NAMESPACE}
+	- kubectl label namespace ${NAMESPACE} monitoring-key=middleware
+	- kubectl create -f deploy/monitor/service_monitor.yaml
+	- kubectl create -f deploy/monitor/operator_service.yaml
+	- kubectl create -f deploy/monitor/prometheus-rule.yaml
+	- kubectl create -f deploy/monitor/grafana-dashboard.yaml
+
+.PHONY: uninstall-service-monitor
+uninstall-service-monitor:
+	@echo Uninstalling monitor service for integr8ly from ${NAMESPACE} :
+	- oc new-project ${NAMESPACE}
+	- kubectl delete -f deploy/monitor/service_monitor.yaml
+	- kubectl delete -f deploy/monitor/operator_service.yaml
+	- kubectl delete -f deploy/monitor/prometheus-rule.yaml
+	- kubectl delete -f deploy/monitor/grafana-dashboard.yaml
 
 .PHONY: build-dev
 build-dev:

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,8 @@ run-local:
 
 .PHONY: create-all
 create-all:
+	@echo Create Mobile Security Service Operator namespace ${NAMESPACE}:
+	- oc new-project ${NAMESPACE}
 	@echo Create Mobile Security Service Operator and Service in the namespace ${NAMESPACE}:
 	make create-oper
 	make create-service-and-db
@@ -91,8 +93,6 @@ delete-all:
 	- kubectl delete -f deploy/cluster_role_binding.yaml
 	- kubectl delete -f deploy/service_account.yaml
 	- kubectl delete -f deploy/operator.yaml
-	@echo Call command to uninstall the Monitor Service in the case of it be installed:
-	- make uninstall-service-monitor
 	- kubectl delete namespace ${NAMESPACE}
 
 .PHONY: create-oper
@@ -151,20 +151,20 @@ delete-db-only:
 	@echo Deleting Mobile Security Service Database only:
 	kubectl delete -f deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
 
-.PHONY: install-service-monitor
-install-service-monitor:
-	@echo Installing service monitor for integr8ly in ${NAMESPACE} :
-	- oc new-project ${NAMESPACE}
+.PHONY: install-monitoring
+install-monitoring:
+	@echo Installing service monitor in ${NAMESPACE} :
+	- oc project ${NAMESPACE}
 	- kubectl label namespace ${NAMESPACE} monitoring-key=middleware
 	- kubectl create -f deploy/monitor/service_monitor.yaml
 	- kubectl create -f deploy/monitor/operator_service.yaml
 	- kubectl create -f deploy/monitor/prometheus-rule.yaml
 	- kubectl create -f deploy/monitor/grafana-dashboard.yaml
 
-.PHONY: uninstall-service-monitor
-uninstall-service-monitor:
-	@echo Uninstalling monitor service for integr8ly from ${NAMESPACE} :
-	- oc new-project ${NAMESPACE}
+.PHONY: uninstall-monitoring
+uninstall-monitoring:
+	@echo Uninstalling monitor service from ${NAMESPACE} :
+	- oc project ${NAMESPACE}
 	- kubectl delete -f deploy/monitor/service_monitor.yaml
 	- kubectl delete -f deploy/monitor/operator_service.yaml
 	- kubectl delete -f deploy/monitor/prometheus-rule.yaml

--- a/README.adoc
+++ b/README.adoc
@@ -142,41 +142,24 @@ $ make delete-all
 
 == Configuration and Options
 
-=== Monitoring for the Integr8ly project
+=== Operator Namespace
 
-The application-monitoring stack provisioned by the
-https://github.com/integr8ly/application-monitoring-operator[application-monitoring-operator] on https://github.com/integr8ly[Integr8ly]
-can be used to gather metrics from the operator. These metrics can be used by Integr8ly's application monitoring to generate  Prometheus metrics, AlertManager alerts and a Grafana dashboard 
-You can run the following commands to install it manually:
+By using the make command `make create-all` the default namespace, e.g `mobile-security-service`, will be created and the operator will be installed on it. You are able to install the operator in another namespace as you wish,
+however, you need setup its roles (RCBA) to by applied on the namespace where the operator will be installed. The namespace name need to be changed in the link:./deploy/cluster_role_binding.yaml[Cluster Role Binding] file in the following line.
 
-[source,shell]
+[source,yaml]
 ----
-# Installation of ServiceMonitor
-kubectl label namespace mobile-security-service monitoring-key=middleware
-kubectl create -f deploy/service_monitor.yaml namespace mobile-security-service
-kubectl create -f deploy/operator_service.yaml namespace mobile-security-service
-
-# Add AlertManager rules to prometheus
-kubectl create -f deploy/prometheus-rule.yaml namespace mobile-security-service
-
-# Add Grafana dashboard 
-kubectl create -f deploy/grafana-dashboard.yaml namespace mobile-security-service
+  # Replace this with the namespace where the operator will be deployed.
+  namespace: mobile-security-service
 ----
 
-As all resource are tied to the namespace mobile-security-service removing this project will remove the above resources however if you wish to remove manually 
+=== Namespace to apply MobileSecurityServiceApp
 
-[source,shell]
-----
-# Delete ServiceMonitor
-kubectl delete -f deploy/service_monitor.yaml namespace mobile-security-service
-kubectl delete -f deploy/operator_service.yaml namespace mobile-security-service
+This operator will just working with the namespaces which are specified in the environment variable `APP_NAMESPACES` and the link:./deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml[MobileSecurityServiceApp CR] which be applied in a NAMESPACE which was not defined on it will be ignored. See its configuration into the link:./deploy/operator.yaml[operator.yaml] file.
 
-# Delete AlertManager rules to prometheus
-kubectl delete -f deploy/prometheus-rule.yaml namespace mobile-security-service
+IMPORTANT:The values should be informed split by `;`.
 
-# Delete Grafana dashboard 
-kubectl delete -f deploy/grafana-dashboard.yaml namespace mobile-security-service
-----
+NOTE: To run the project locally export the ENV VAR. E.g `export APP_NAMESPACES=mobile-security-service-apps`
 
 === Oauth Configuration
 
@@ -191,13 +174,49 @@ NOTE:
 * All values used in the default configuration are sourced from the config-map which is managed and created by the Operator. This config map will be created in the Operator namespace and its name is defined by the attribute `configMapName` in the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService CR].
 * If the name of this ConfigMap is not specified then the name of the Mobile Security Service instance will be used instead.
 
-=== Namespaces for the MobileSecurityServiceCR
+=== Monitor Service (Metrics) for the Integr8ly project
 
-This operator will just working with the namespaces which are specified in the environment variable `APP_NAMESPACES` and the link:./deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml[MobileSecurityServiceApp CR] which be applied in a NAMESPACE which was not defined on it will be ignored. See its configuration into the link:./deploy/operator.yaml[operator.yaml] file.
+The application-monitoring stack provisioned by the
+https://github.com/integr8ly/application-monitoring-operator[application-monitoring-operator] on https://github.com/integr8ly[Integr8ly]
+can be used to gather metrics from this operator. These metrics can be used ONLY by Integr8ly's application monitoring to generate Prometheus metrics, AlertManager alerts and a Grafana dashboard
 
-IMPORTANT:The values should be informed split by `;`.
+Run the following commands if this project was installed with the make commands in the default namespace to enable this service.
 
-NOTE: To run the project locally export the ENV VAR. E.g `export APP_NAMESPACES=mobile-security-service-apps`
+[source,shell]
+----
+make install-service-monitor
+----
+
+Also, you are allowed to setup it manually as follows.
+
+[source,shell]
+----
+# Go to the operator namespace
+oc project mobile-security-service
+
+# Installation of ServiceMonitor
+kubectl label namespace mobile-security-service monitoring-key=middleware
+kubectl create -f deploy/monitor/service_monitor.yaml
+kubectl create -f deploy/monitor/operator_service.yaml
+
+# Add AlertManager rules to prometheus
+kubectl create -f deploy/monitor/prometheus-rule.yaml
+
+# Add Grafana dashboard
+kubectl create -f deploy/monitor/grafana-dashboard.yaml
+----
+
+IMPORTANT: The link:./deploy/monitor/service_monitor.yaml[ServiceMonitor], link:./deploy/monitor/prometheus-rule.yaml[Prometheus Rules], link:./deploy/monitor/operator-service.yaml[Operator Service], and link:./deploy/monitor/grafana-dashboard[Grafana Dashboard] needs to be applied in the same namespace where the operator is installed.
+
+NOTE: The namespace is setup manually in this files as follows example from the link:./deploy/prometheus-rule.yaml[Prometheus Rules].
+
+[source,yaml]
+----
+  expr: |
+          (1-absent(kube_pod_status_ready{condition="true", namespace="mobile-security-service"})) or sum(kube_pod_status_ready{condition="true", namespace="mobile-security-service"}) != 3
+
+[source,shell]
+----
 
 === Database image and parameters
 
@@ -376,7 +395,7 @@ Images for the mobile-security-service-operator are published to https://quay.io
 - For every change merged to master a new image with the `master` tag is published
 - For every change merged that has a git tag a new image with the `<operator-version>` and `latest` tags are published
 
-If the image does not get built and pushed automatically the job may be re-run manually via the https://circleci.com/gh/aerogear/mobile-security-service-operator[CI dashboard]. 
+If the image does not get built and pushed automatically the job may be re-run manually via the https://circleci.com/gh/aerogear/mobile-security-service-operator[CI dashboard].
 
 ==== Dev images
 
@@ -428,6 +447,8 @@ NOTE: The image/tag used from https://github.com/aerogear/mobile-security-servic
 | `make push-latest`               | Used by CI to push image built by `make build-latest` to https://quay.io/repository/aerogear/mobile-security-service-operator[quay.io registry].
 | `make run-local`                 | Run the operator locally for development purposes.
 | `make debug-setup`               | Setup environment for debug proposes.
+| `make install-service-monitor`   | Install Service Monitor which just work with https://github.com/integr8ly in order to provide metrics
+| `make uninstall-service-monitor` | Uninstall Service Monitor which just work with https://github.com/integr8ly in order to provide metrics
 | `make vet`                       | Examines source code and reports suspicious constructs using https://golang.org/cmd/vet/[vet].
 | `make fmt`                       | Formats code using https://golang.org/cmd/gofmt/[gofmt].
 |===

--- a/README.adoc
+++ b/README.adoc
@@ -86,7 +86,7 @@ To verify the installation has been successful run the following
 [source,shell]
 ----
 # check the project exists 
-$ oc project mobile-security-service-operator
+$ oc project mobile-security-service
 # check the pods are deployed
 $ oc get pods
 NAME                                                READY     STATUS    RESTARTS   AGE
@@ -144,8 +144,7 @@ $ make delete-all
 
 === Operator Namespace
 
-By using the make command `make create-all` the default namespace, e.g `mobile-security-service`, will be created and the operator will be installed on it. You are able to install the operator in another namespace as you wish,
-however, you need setup its roles (RCBA) to by applied on the namespace where the operator will be installed. The namespace name need to be changed in the link:./deploy/cluster_role_binding.yaml[Cluster Role Binding] file in the following line.
+By using the make command `make create-all` the default namespace, e.g `mobile-security-service`, will be created and the operator will be installed in it. You are able to install the operator in another namespace as you wish, however, you need setup its roles (RBAC) to by applied on the namespace where the operator will be installed. The namespace name need to be changed in the link:./deploy/cluster_role_binding.yaml[Cluster Role Binding] file in the following line.
 
 [source,yaml]
 ----
@@ -155,11 +154,11 @@ however, you need setup its roles (RCBA) to by applied on the namespace where th
 
 === Namespace to apply MobileSecurityServiceApp
 
-This operator will just working with the namespaces which are specified in the environment variable `APP_NAMESPACES` and the link:./deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml[MobileSecurityServiceApp CR] which be applied in a NAMESPACE which was not defined on it will be ignored. See its configuration into the link:./deploy/operator.yaml[operator.yaml] file.
+Only namespaces specified in the environment variable `APP_NAMESPACES` can be used to apply Apps. If the link:./deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml[MobileSecurityServiceApp CR] is applied to a namespace that is not specified in `APP_NAMESPACES` it will be ignored. Refer to configuration in the link:./deploy/operator.yaml[operator.yaml] file.
 
-IMPORTANT:The values should be informed split by `;`.
+IMPORTANT: The values should be split by `;`. E.g `mobile-security-service-apps;example-namespace-apps`
 
-NOTE: To run the project locally export the ENV VAR. E.g `export APP_NAMESPACES=mobile-security-service-apps`
+NOTE: To run the project locally export the ENV VAR. E.g. `export APP_NAMESPACES=mobile-security-service-apps`
 
 === Oauth Configuration
 
@@ -174,17 +173,19 @@ NOTE:
 * All values used in the default configuration are sourced from the config-map which is managed and created by the Operator. This config map will be created in the Operator namespace and its name is defined by the attribute `configMapName` in the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService CR].
 * If the name of this ConfigMap is not specified then the name of the Mobile Security Service instance will be used instead.
 
-=== Monitor Service (Metrics) for the Integr8ly project
+=== Monitoring Service (Metrics)
 
 The application-monitoring stack provisioned by the
 https://github.com/integr8ly/application-monitoring-operator[application-monitoring-operator] on https://github.com/integr8ly[Integr8ly]
-can be used to gather metrics from this operator. These metrics can be used ONLY by Integr8ly's application monitoring to generate Prometheus metrics, AlertManager alerts and a Grafana dashboard
+can be used to gather metrics from this operator. These metrics can be used by Integr8ly's application monitoring to generate Prometheus metrics, AlertManager alerts and a Grafana dashboard.
 
-Run the following commands if this project was installed with the make commands in the default namespace to enable this service.
+It is required that the https://github.com/integr8ly/grafana-operator[integr8ly/Grafana] and https://github.com/coreos/prometheus-operator[Prometheus] operators are installed. For further detail see https://github.com/integr8ly/application-monitoring-operator[integr8ly/application-monitoring-operator].
+
+The following commands will enable the monitoring service where the operator has been installed in the default namespace with the make commands.
 
 [source,shell]
 ----
-make install-service-monitor
+make install-monitoring
 ----
 
 Also, you are allowed to setup it manually as follows.
@@ -192,23 +193,34 @@ Also, you are allowed to setup it manually as follows.
 [source,shell]
 ----
 # Go to the operator namespace
-oc project mobile-security-service
 
-# Installation of ServiceMonitor
-kubectl label namespace mobile-security-service monitoring-key=middleware
-kubectl create -f deploy/monitor/service_monitor.yaml
-kubectl create -f deploy/monitor/operator_service.yaml
-
-# Add AlertManager rules to prometheus
-kubectl create -f deploy/monitor/prometheus-rule.yaml
-
-# Add Grafana dashboard
-kubectl create -f deploy/monitor/grafana-dashboard.yaml
+$ oc project mobile-security-service
 ----
 
-IMPORTANT: The link:./deploy/monitor/service_monitor.yaml[ServiceMonitor], link:./deploy/monitor/prometheus-rule.yaml[Prometheus Rules], link:./deploy/monitor/operator-service.yaml[Operator Service], and link:./deploy/monitor/grafana-dashboard[Grafana Dashboard] needs to be applied in the same namespace where the operator is installed.
+[source,shell]
+----
+# Installation of ServiceMonitor
 
-NOTE: The namespace is setup manually in this files as follows example from the link:./deploy/prometheus-rule.yaml[Prometheus Rules].
+$ kubectl label namespace mobile-security-service monitoring-key=middleware
+$ kubectl create -f deploy/monitor/service_monitor.yaml
+$ kubectl create -f deploy/monitor/operator_service.yaml
+----
+
+[source,shell]
+----
+# Add AlertManager rules to prometheus
+
+$ kubectl create -f deploy/monitor/prometheus-rule.yaml
+----
+
+[source,shell]
+----
+# Add Grafana dashboard
+
+$ kubectl create -f deploy/monitor/grafana-dashboard.yaml
+----
+
+IMPORTANT: The namespaces are setup manually in the files link:./deploy/monitor/service_monitor.yaml[ServiceMonitor], link:./deploy/monitor/prometheus-rule.yaml[Prometheus Rules], link:./deploy/monitor/operator-service.yaml[Operator Service], and link:./deploy/monitor/grafana-dashboard[Grafana Dashboard]. Following an example from the link:./deploy/prometheus-rule.yaml[Prometheus Rules]. You should replace them if the operator is not installed in the default namespace.
 
 [source,yaml]
 ----
@@ -217,6 +229,8 @@ NOTE: The namespace is setup manually in this files as follows example from the 
 
 [source,shell]
 ----
+
+NOTE:  `make uninstall-monitoring` will uninstall the Service.
 
 === Database image and parameters
 
@@ -447,8 +461,8 @@ NOTE: The image/tag used from https://github.com/aerogear/mobile-security-servic
 | `make push-latest`               | Used by CI to push image built by `make build-latest` to https://quay.io/repository/aerogear/mobile-security-service-operator[quay.io registry].
 | `make run-local`                 | Run the operator locally for development purposes.
 | `make debug-setup`               | Setup environment for debug proposes.
-| `make install-service-monitor`   | Install Service Monitor which just work with https://github.com/integr8ly in order to provide metrics
-| `make uninstall-service-monitor` | Uninstall Service Monitor which just work with https://github.com/integr8ly in order to provide metrics
+| `make install-monitoring`        | Install Monitoring Service in order to provide metrics
+| `make uninstall-monitoring`      | Uninstall Monitoring Service in order to provide metrics
 | `make vet`                       | Examines source code and reports suspicious constructs using https://golang.org/cmd/vet/[vet].
 | `make fmt`                       | Formats code using https://golang.org/cmd/gofmt/[gofmt].
 |===

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: mobile-security-service-operator
-  # Replace this with the namespace the operator is deployed in.
+  # Replace this with the namespace where the operator will be deployed.
   namespace: mobile-security-service
 roleRef:
   kind: ClusterRole

--- a/deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml
+++ b/deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml
@@ -1,8 +1,14 @@
+# Example of a CR to create/apply and allow the operator manage the applications.
+# Note that a similar YAML file should be generated for each app which will be created/manage by the Mobile Security Service
 apiVersion: mobile-security-service.aerogear.com/v1alpha1
 kind: MobileSecurityServiceApp
 metadata:
   name: mobile-security-service-app
 spec:
+  # The appName spec defines the appName of the app in the Service side, it also is used to create the ConfigMap name
+  # NOTE: To update the name just update this spec and re-apply the CR
   appName: "example-appname"
-  # The appId spec defines the appId of the app used to bind the service
+  # The appId spec defines the appId  of the app in the Service side and it is also used to manage the ConfigMap for this app
+  # IMPORTANT: This is a unique identifier which means that each app managed by the Operator and its service
+  # needs to have a unique value for this spec
   appId: "appid.example.com"

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
@@ -1,3 +1,4 @@
+# This CR defines the specs of the Mobile Security Service which will be installed/managed by the Operator
 apiVersion: mobile-security-service.aerogear.com/v1alpha1
 kind: MobileSecurityService
 metadata:
@@ -10,9 +11,10 @@ spec:
   # The following properties will define the resources for the Mobile Security Service App deployment
   memoryLimit: "512Mi"
   memoryRequest: "512Mi"
+  # The clusterProtocol is required and used to generated the Public Host URL
   clusterProtocol: "http" # Options [http or https]
-  # The following values will be used to create the ConfigMap with the Environment Variables
-  # which will be used by thee Mobile Security Service App and Database
+  # The following values are used to create the ConfigMap and the Environment Variables which will use these values
+  # These values are used for both the Mobile Security Service and its Database
   databaseName: "mobile_security_service"
   databasePassword: "postgres"
   databaseUser: "postgresql"

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
@@ -2,7 +2,6 @@ apiVersion: mobile-security-service.aerogear.com/v1alpha1
 kind: MobileSecurityService
 metadata:
   name: mobile-security-service
-  namespace: mobile-security-service
 spec:
   size: 1
   # It is the image:tag used to create the mobile security service deployment

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
@@ -1,3 +1,4 @@
+# This CR defines the specs of the PostgreSQL Database which will be installed/managed by the Operator
 apiVersion: mobile-security-service.aerogear.com/v1alpha1
 kind: MobileSecurityServiceDB
 metadata:

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicedb_cr.yaml
@@ -2,7 +2,6 @@ apiVersion: mobile-security-service.aerogear.com/v1alpha1
 kind: MobileSecurityServiceDB
 metadata:
   name: mobile-security-service-db
-  namespace: mobile-security-service
 spec:
   size: 1
   # The imaged used in this project is from Red Hat. See more in https://docs.okd.io/latest/using_images/db_images/postgresql.html

--- a/deploy/monitor/operator_service.yaml
+++ b/deploy/monitor/operator_service.yaml
@@ -1,4 +1,4 @@
-# Monitor Service (Metrics) for integr8ly
+# Monitor Service (Metrics)
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/monitor/operator_service.yaml
+++ b/deploy/monitor/operator_service.yaml
@@ -1,10 +1,10 @@
+# Monitor Service (Metrics) for integr8ly
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     name: mobile-security-service-operator
   name: mobile-security-service-operator
-  namespace: mobile-security-service
   resourceVersion: '66190'
   selfLink: >-
     /api/v1/namespaces/mobile-security-service/services/mobile-security-service-operator

--- a/deploy/monitor/prometheus-rule.yaml
+++ b/deploy/monitor/prometheus-rule.yaml
@@ -1,3 +1,4 @@
+# Monitor Service (Metrics) for integr8ly
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/deploy/monitor/prometheus-rule.yaml
+++ b/deploy/monitor/prometheus-rule.yaml
@@ -1,4 +1,4 @@
-# Monitor Service (Metrics) for integr8ly
+# Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/deploy/monitor/service_monitor.yaml
+++ b/deploy/monitor/service_monitor.yaml
@@ -1,3 +1,4 @@
+# Monitor Service (Metrics) for integr8ly
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/deploy/monitor/service_monitor.yaml
+++ b/deploy/monitor/service_monitor.yaml
@@ -1,4 +1,4 @@
-# Monitor Service (Metrics) for integr8ly
+# Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9296
## What
- Remove the fixed namespace from all CRs 
- Add an explanation in the README regards the need to set up the ClusterRole to be applied in the namespace where the Operator will be installed.  
- Create specific make command for the MonitorService 
- Update the Readme to make clear what is the MonitorService propose.

## Why
- The Operator should be installed in any namespace defined by the cluster admin

## Verification Steps
With this PR.

### Check it working in the default namespace

1. Do the default installation of the operator by the command `make create-all`
2. Go to the default app_namespace `oc project mobile-security-service-apps` and check that the `create-app and delete-app` commands still working fine. 

### Check it working in the any other namespace
1. Clean all by using`make delete-all`
2. Create a new namespace `oc new-project oper-test`
3. Replace the namespace in the Cluster Role Binding (`oper-test`)
4. Execute the commands `make create-oper` then `make create-service-and-db`
5. Check that all is installed with success in the `oper-test`
6.  Go to the default app_namespace `oc project mobile-security-service-apps` and check that the `create-app and delete-app` commands still working fine. 

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

<img width="1664" alt="Screenshot 2019-05-29 at 16 14 47" src="https://user-images.githubusercontent.com/7708031/58568925-0fb26700-822d-11e9-8db1-48015f20f074.png">
<img width="1593" alt="Screenshot 2019-05-29 at 16 14 38" src="https://user-images.githubusercontent.com/7708031/58568926-0fb26700-822d-11e9-8814-394e483a2252.png">
