### PR TITLE
make command refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@ jobs:
           name: Install dep
           command: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run: make setup
-      - run: make build_linux
-      - run: make test
-      - run: make test-integration-cover
+      - run: make code/build/linux
+      - run: make test/run
+      - run: make test/integration-cover
       - run: /go/bin/goveralls -coverprofile=coverage-all.out -service=circle-ci -repotoken=ycY6oBXw8F89TEabp46VXSRpVFjfYBujH
 
   image_push_master:
@@ -36,9 +36,9 @@ jobs:
       - run: make setup
       # circle ci key required for docker builds
       - setup_remote_docker
-      - run: make build_linux 
-      - run: make build-master
-      - run: make push-master
+      - run: make code/build/linux
+      - run: make image/build/master
+      - run: make image/push/master
 
   image_release:
     working_directory: /go/src/github.com/aerogear/mobile-security-service-operator
@@ -55,10 +55,8 @@ jobs:
       - run: make setup
       # circle ci key required for docker builds
       - setup_remote_docker
-      - run: make build-release
-      - run: make push-release
-      - run: make build-latest
-      - run: make push-latest
+      - run: make image/build/release
+      - run: make image/push/release
 
 workflows:
   version: 2

--- a/README.adoc
+++ b/README.adoc
@@ -71,16 +71,16 @@ $ minishift config set insecure-registry 172.30.0.0/16
 $ minishift start
 ----
 
-=== Installing Mobile Security Service by Operator
+=== Installing Mobile Security Service
 
-Use the following command to create the Operator, Service and its Database as apply the roles on the cluster.
+Use the following command to install the Operator, Service and its Database.
+
+NOTE: To install you need be logged in as a user with cluster priviledges like the `system:admin` user. E.g. By using: `oc login -u system:admin`.
 
 [source,shell]
 ----
-$ make create-all
+$ make install
 ----
-
-IMPORTANT: To create all you need be logged as admin. Use `oc login -u system:admin`.
 
 To verify the installation has been successful run the following
 [source,shell]
@@ -114,10 +114,10 @@ mobile-security-service-operator-785cbdbf46-wq2lf   1/1       Running   0       
 +
 [source,shell]
 ----
-$ make create-app
+$ make example-app/apply
 ----
 
-NOTE: This command will just apply the link:./deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml[MobileSecurityServiceApp CR] example with `kubectl create -f deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml`
+NOTE: This command will just apply the link:./deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml[MobileSecurityServiceApp CR] example with `kubectl apply -f deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml`
 
 === Deleting/Unbinding an app
 
@@ -125,26 +125,28 @@ NOTE: This command will just apply the link:./deploy/crds/examples/mobile-securi
 +
 [source,shell]
 ----
-$ make delete-app
+$ make example-app/delete
 ----
 
 IMPORTANT: This command will just delete the link:./deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml[MobileSecurityServiceApp CR] example with `kubectl delete -f deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml`
 NOTE: The Rest Service endpoint to delete it is called in the finalizer of the link:./deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml[MobileSecurityServiceApp CR] and the CR will be just allowed to be removed when the app is no longer available in its Service.
 
-=== Removing
+=== Uninstalling
 
-Use the following command to delete the Operator, the Service and its Database as roles from the cluster.
+Use the following command to delete the Operator, the Service and its Database and all related configuration applied by the `install` of this project.
 
 [source,shell]
 ----
-$ make delete-all
+$ make uninstall
 ----
+
+NOTE: To uninstall you need be logged in as a user with cluster priviledges like the `system:admin` user. E.g. By using: `oc login -u system:admin`.
 
 == Configuration and Options
 
 === Operator Namespace
 
-By using the make command `make create-all` the default namespace, e.g `mobile-security-service`, will be created and the operator will be installed in it. You are able to install the operator in another namespace as you wish, however, you need setup its roles (RBAC) to by applied on the namespace where the operator will be installed. The namespace name need to be changed in the link:./deploy/cluster_role_binding.yaml[Cluster Role Binding] file in the following line.
+By using the command `make install` the default namespace `mobile-security-service`,  defined in the link:./Makefile[Makefile] will be created and the operator will be installed in this namespace. You are able to install the operator in another namespace if you wish, however, you need to set up its roles (RBAC) in order to apply them on the namespace where the operator will be installed. The namespace name needs to be changed in the link:./deploy/cluster_role_binding.yaml[Cluster Role Binding] file. Note, that you also need to change the namespace in the link:./Makefile[Makefile] in order to use the command `make install` for another namespace. 
 
 [source,yaml]
 ----
@@ -180,7 +182,7 @@ The following commands will enable the monitoring service where the operator has
 
 [source,shell]
 ----
-make install-monitoring
+make install
 ----
 
 Also, you are allowed to setup it manually as follows.
@@ -215,6 +217,9 @@ $ kubectl create -f deploy/monitor/prometheus-rule.yaml
 $ kubectl create -f deploy/monitor/grafana-dashboard.yaml
 ----
 
+This operator will only working with the namespaces which are specified in the environment variable `APP_NAMESPACES`. Any link:./deploy/crds/examples/mobile-security-service_v1alpha1_mobilesecurityserviceapp_cr.yaml[MobileSecurityServiceApp CR] which is created/applied in a NAMESPACE which is not defined in `APP_NAMESPACES` will be ignored. See the EnvVar configuration into the link:./deploy/operator.yaml[operator.yaml] file. Also, note that the valid namespaces can be managed by the OCP UI.
+
+
 IMPORTANT: The namespaces are setup manually in the files link:./deploy/monitor/service_monitor.yaml[ServiceMonitor], link:./deploy/monitor/prometheus-rule.yaml[Prometheus Rules], link:./deploy/monitor/operator-service.yaml[Operator Service], and link:./deploy/monitor/grafana-dashboard[Grafana Dashboard]. Following an example from the link:./deploy/prometheus-rule.yaml[Prometheus Rules]. You should replace them if the operator is not installed in the default namespace.
 
 [source,yaml]
@@ -225,7 +230,7 @@ IMPORTANT: The namespaces are setup manually in the files link:./deploy/monitor/
 [source,shell]
 ----
 
-NOTE:  `make uninstall-monitoring` will uninstall the Service.
+NOTE:  `make monitoring/uninstall` will uninstall the Service.
 
 === Database image and parameters
 
@@ -327,7 +332,7 @@ The following command will install the operator in the cluster and run the chang
 
 [source,yaml]
 ----
-$ make run-local
+$ make code/run/local
 ----
 
 IMPORTANT: The local changes are applied when the command `operator-sdk up local --namespace={namespace}` is executed then it is not a hot deploy and to get the latest changes you need re-run the command.
@@ -343,7 +348,7 @@ NOTE: The code needs to be compiled/built first.
 
 [source,shell]
 ----
-$ make debug-setup
+$ make setup/debug
 $ cd cmd/manager/
 $ dlv debug --headless --listen=:2345 --api-version=2
 ----
@@ -354,7 +359,7 @@ Then, debug the project from the IDE by using the default setup of `Go Remote` o
 
 [source,shell]
 ----
-$ make debug-setup
+$ make setup/debug
 $ dlv --listen=:2345 --headless=true --api-version=2 exec ./build/_output/bin/mobile-security-service-operator-local  --
 ----
 
@@ -414,8 +419,8 @@ The following commands will build the project and publish it to our https://quay
 
 [source,shell]
 ----
-$ make build-dev
-$ make push-dev
+$ make image/build/dev
+$ make image/push/dev
 ----
 
 NOTE: You will require `quay.io` credentials and access to publish images to the `quay.io/aerogear` organisation.
@@ -434,36 +439,39 @@ NOTE: The image/tag used from https://github.com/aerogear/mobile-security-servic
 
 == Makefile command reference
 
+=== Application Commands
+
 |===
 | *Command*                        | *Description*
-| `make create-all`                | Create {namespace} namespace, operator, service and roles.
-| `make delete-all`                | Delete {namespace} namespace, operator, service and roles.
-| `make create-oper`               | Create {namespace}  namespace, operator and roles.
-| `make delete-oper`               | Delete {namespace}  namespace, operator and roles.
-| `make create-service-and-db`     | Create Mobile Security Service App and its database in the project.
-| `make create-service-only`       | Create Mobile Security Service App without its database.
-| `make delete-service-and-db`     | Delete Mobile Security Service App and its database.
-| `make delete-service-only`       | Delete Mobile Security Service App only.
-| `make create-db-only`            | Create Mobile Security Service Database without its application.
-| `make delete-db-only`            | Delete Mobile Security Service Database only.
-| `make create-app`                | Apply the App CR . (Create/Update app in the cluster and Service, also creates ConfigMap with the public host endpoint for the init config in the mobile device(SDK) ).
-| `make delete-app`                | Delete the App CR. (Delete app from the Service and SDKConfigMap).
-| `make build-dev`                 | Build operator dev image with tag `quay.io/aerogear/mobile-security-service-operator:<version>-dev`.
-| `make push-dev`                  | Push operator dev image to https://quay.io/repository/aerogear/mobile-security-service-operator[quay.io].
-| `make build-master`              | Used by CI to build operator image from `master` branch and add `:master` tag.
-| `make push-master`               | Used by CI to push image built by `make build-master` to https://quay.io/repository/aerogear/mobile-security-service-operator[quay.io registry].
-| `make build-release`             | Used by CI to build operator image from a tagged commit and add `:<version>` tag.
-| `make push-release`              | Used by CI to push image built by `make build-release` to https://quay.io/repository/aerogear/mobile-security-service-operator[quay.io registry].
-| `make build-latest`              | Used by CI to build operator image from a tagged commit and add `:latest` tag.
-| `make push-latest`               | Used by CI to push image built by `make build-latest` to https://quay.io/repository/aerogear/mobile-security-service-operator[quay.io registry].
-| `make run-local`                 | Run the operator locally for development purposes.
-| `make debug-setup`               | Setup environment for debug proposes.
-| `make install-monitoring`        | Install Monitoring Service in order to provide metrics
-| `make uninstall-monitoring`      | Uninstall Monitoring Service in order to provide metrics
-| `make vet`                       | Examines source code and reports suspicious constructs using https://golang.org/cmd/vet/[vet].
-| `make fmt`                       | Formats code using https://golang.org/cmd/gofmt/[gofmt].
+| `install`                   | Creates the `{namespace}` namespace, application CRDS, cluster role and service account. Installs the operator and the Service and DB
+| `make uninstall`                 | Uninstalls the operator and the Service and DB. Deletes the `{namespace}`` namespace, application CRDS, cluster role and service account and the app namespace. i.e. all configuration applied by `make install`
+| `make example-app/apply`         | Applies the Example App CR . (Create/Update app in the cluster and Service, also creates ConfigMap with the public host endpoint for the init config in the mobile device(SDK) ).
+| `make example-app/delete`        | Deletes the Example App CR. (Delete app from the Service and SDKConfigMap).
+| `make refresh-operator-image`    | Deletes and applies the operator in order to refresh the image when a tag is not changed (development use)
+| `make monitoring/install`        | Installs Monitoring Service in order to provide metrics
+| `make monitoring/uninstall`      | Uninstalls Monitoring Service in order to provide metrics, i.e. all configuration applied by `make monitoring/install`
 |===
 
+=== Local Development
+
+|===
+| `make code/run-local`                 | Runs the operator locally for development purposes.
+| `make setup/debug`               | Sets up environment for debugging proposes.
+| `make image/build/dev`                 | Builds operator dev image with tag `quay.io/aerogear/mobile-security-service-operator:<version>-dev`.
+| `make image/push/dev`                  | Pushes operator dev image to https://quay.io/repository/aerogear/mobile-security-service-operator[quay.io].
+| `make code/vet`                       | Examines source code and reports suspicious constructs using https://golang.org/cmd/vet/[vet].
+| `make code/fmt`                       | Formats code using https://golang.org/cmd/gofmt/[gofmt].
+|===
+
+=== CI
+
+|===
+| `make test/run`                      | Runs test suite
+| `make test/integration-cover`    | Run coverage check
+| `make image/build/master`              | Used by CI to build operator image from `master` branch and add `:master` tag.
+| `make image/push/master`               | Used by CI to push the `master` image to https://quay.io/repository/aerogear/mobile-security-service-operator[quay.io registry].
+| `make image/build/release`             | Used by CI to build operator image from a tagged commit and add `:<version>` and `latest` tag.
+| `make image/push/release`              | Used by CI to push the `release` and `latest` image to https://quay.io/repository/aerogear/mobile-security-service-operator[quay.io registry].
 
 NOTE: The link:./Makefile[Makefile] is implemented with tasks which you should use to work with.
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"runtime"
+
 	"github.com/aerogear/mobile-security-service-operator/pkg/apis"
 	"github.com/aerogear/mobile-security-service-operator/pkg/controller"
 	routev1 "github.com/openshift/api/route/v1"
@@ -13,8 +16,6 @@ import (
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"github.com/spf13/pflag"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"os"
-	"runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"

--- a/pkg/controller/mobilesecurityserviceapp/controller.go
+++ b/pkg/controller/mobilesecurityserviceapp/controller.go
@@ -2,6 +2,7 @@ package mobilesecurityserviceapp
 
 import (
 	"context"
+
 	"github.com/aerogear/mobile-security-service/pkg/models"
 
 	mobilesecurityservicev1alpha1 "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1"


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9223

## What
- Refactor the commands to include 
-- An install/uninstall for the project
-- refresh-operator-image which gives us the ability to pull in a new image on the same tag without having to delete and create everything in order to test updated dev images.
-- syntax following category/command where appropriate
- Split the commands in the README to 3 tables


## Why
We've got a lot of commands in the Makefile, now that the project has progressed they needed a little refactor

## How
See `What`

## Verification Steps
 
EDIT: Use this image for the operator test quay.io/laurafitzgerald/mobile-security-service-operator:0.1.0-dev-ag

1. Run `make install`
2. Verify that the operator and mss project are installed successfully

3. Run `make apply-example-app`
4. Verify the app cr is created and is created in the service

5. Run `make apply-example-app`
6. Verify the app cr is updated and is updated in the service

7. Run `make delete-example-app`
8. Verify the app cr is deleted

Repeat 3 - 8 in a different project to `mobile-security-service-apps`
Verify that the cr gets created/updated/deleted but the app doesn't get created in the service.

9. Run `make uninstall`
10. Verify that the operator and mss project are uninstalled successfully. the other resources, crds, namespace etc. should all stay in place.

11. Run setup and code tasks to ensure that they are all working correctly.
12. Verify that the ci tasks work as expected - aka did the build pass?

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

