### PR TITLE
fix(script) : Remove AEROGEAR check from the commit msg

### DIFF
--- a/scripts/commit-filter-check.sh
+++ b/scripts/commit-filter-check.sh
@@ -14,41 +14,31 @@ commit_message_check (){
       gitmessage=`git log --format=%B -n 1 "$i"`
       
       ####################### TEST STRINGS comment out line 13 to use #########################################
-      #gitmessage="feat sdasdsadsaas (AEROGEAR-asdsada)"
-      #gitmessage="feat(some txt): some txt (AEROGEAR-****)"
-      #gitmessage="docs(some txt): some txt (AEROGEAR-1234)"
-      #gitmessage="fix(some txt): some txt (AEROGEAR-5678)"
+      #gitmessage="feat sdasdsadsaas "
+      #gitmessage="feat(some txt): some txt "
+      #gitmessage="docs(some txt): some txt"
+      #gitmessage="fix(some txt): some txt"
       #########################################################################################################
-      
+
       messagecheck=`echo $gitmessage | grep -w "feat\|fix\|docs\|breaking"`
       if [ -z "$messagecheck" ]
-      then 
+      then
             echo "Your commit message must begin with one of the following"
             echo "  feat(feature-name)"
             echo "  fix(fix-name)"
             echo "  docs(docs-change)"
             echo " "
       fi
-      messagecheck=`echo $gitmessage | grep "(AEROGEAR-"`
-      if  [ -z "$messagecheck" ]
-      then 
-            echo "Your commit message must end with the following"
-            echo "  (AEROGEAR-****)"
-            echo "Where **** is the Jira number"
-            echo " " 
-      fi
       messagecheck=`echo $gitmessage | grep ": "`
       if  [ -z "$messagecheck" ]
-      then 
+      then
             echo "Your commit message has a formatting error please take note of special characters '():' position and use in the example below"
-            echo "   type(some txt): some txt (AEROGEAR-****)"
-            echo "Where 'type' is fix, feat, docs or breaking and **** is the Jira number"
+            echo "   type(some txt): some txt"
+            echo "Where 'type' is fix, feat, docs or breaking"
             echo " "
       fi
 
-      messagecheck=`echo $gitmessage | grep -w "feat\|fix\|docs\|breaking" | grep "(AEROGEAR-" | grep ": "`
-
-      
+      messagecheck=`echo $gitmessage | grep -w "feat\|fix\|docs\|breaking" | grep ": "`
 
       # check to see if the messagecheck var is empty
       if [ -z "$messagecheck" ]


### PR DESCRIPTION
## Motivation
Unable to use the commit hooks when the task is not tracked in the AEROGEAR

## What
- Remove the check that makes be mandatory have the "AEROGEAR-*****" from the checks

## Why
For example, now we are doing tasks tracked in the integr8ly project for it. In this way, no make sense we have this check and in my pov, it has not been so helpful at all. 

## How
- just remove the specify checks for it from the script called by the git hook

## Verification Steps
Do any git operation which will call it and do not add AEROGEAR in the msg
Following the test performed. 
 
<img width="1026" alt="Screenshot 2019-06-14 at 10 30 24" src="https://user-images.githubusercontent.com/7708031/59499779-fc8bd200-8e8f-11e9-94f9-569ca6022309.png">

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO


