### PR TITLE
fix(deployment): remove TypeMeta from db deployment

### DIFF
--- a/pkg/controller/mobilesecurityservicedb/deployments.go
+++ b/pkg/controller/mobilesecurityservicedb/deployments.go
@@ -15,10 +15,6 @@ func (r *ReconcileMobileSecurityServiceDB) buildDBDeployment(db *mobilesecuritys
 	auto := true
 	replicas := db.Spec.Size
 	dep := &v1beta1.Deployment{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "extensions/v1beta1",
-			Kind:       "Deployment",
-		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      db.Name,
 			Namespace: db.Namespace,


### PR DESCRIPTION
## Motivation
We should not set the TypeMeta

## What
Remove the TypeMeta from the DB deployment

## Why
It is set automatically when the object is instanced 

## Steps to Verify
- Check the CI.