### PR TITLE
(fix)version: use 0.1.0 of mobile-security-service (INTLY-1890)

### DIFF
--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
@@ -37,7 +37,7 @@ spec:
   # Service Container
   # ---------------------------------
 
-  image: "quay.io/aerogear/mobile-security-service:latest"
+  image: "quay.io/aerogear/mobile-security-service:0.1.0"
   containerName: "application"
   memoryLimit: "512Mi"
   memoryRequest: "512Mi"

--- a/pkg/controller/mobilesecurityservice/mandatory_specs.go
+++ b/pkg/controller/mobilesecurityservice/mandatory_specs.go
@@ -18,7 +18,7 @@ const (
 	clusterProtocol               = "http"
 	memoryLimit                   = "512Mi"
 	memoryRequest                 = "512Mi"
-	image                         = "quay.io/aerogear/mobile-security-service:latest"
+	image                         = "quay.io/aerogear/mobile-security-service:0.1.0"
 	containerName                 = "application"
 	oAuthImage                    = "docker.io/openshift/oauth-proxy:v1.1.0"
 	oAuthContainerName            = "oauth-proxy"

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.1.0"
+	Version = "0.1.1"
 )


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-1890

## What
Fix the version of mobile security service deployed by the operator for use in the integreatly installer

## Why
Fix the version of mobile security service deployed by the operator for use in the integreatly installer

## How
See changes

## Verification Steps

Deploy the operator using the template cr
1. Run `make install`
2. Verify that the image used in the Mobile Security Service pod that is used is tag 0.1.0 

![Screenshot 2019-06-19 at 09 11 42](https://user-images.githubusercontent.com/6498727/59748118-5286be00-9272-11e9-876b-d23268aabbf9.png)

(Optionally) Deploy the operator using the example cr below to verify that the image overrides
Using image: `quay.io/laurafitzgerald/mobile-security-service-operator:intly-1890`

Follow steps 1. and 2. as above. 

Cr Example
```
apiVersion: mobile-security-service.aerogear.com/v1alpha1
kind: MobileSecurityService
metadata:
  name: mobile-security-service
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Make the version changes
- [ ] Create a 0.1.1 tag to be used in the integreatly installer

 
