### PR TITLE
Intly 1892

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ monitoring/install:
 	- oc project ${NAMESPACE}
 	- kubectl label namespace ${NAMESPACE} monitoring-key=middleware
 	- kubectl create -f deploy/monitor/service_monitor.yaml
+	- kubectl create -f deploy/monitor/mss_service_monitor.yaml
 	- kubectl create -f deploy/monitor/operator_service.yaml
 	- kubectl create -f deploy/monitor/prometheus-rule.yaml
 	- kubectl create -f deploy/monitor/grafana-dashboard.yaml
@@ -96,6 +97,7 @@ monitoring/uninstall:
 	- oc project ${NAMESPACE}
 	- kubectl delete -f deploy/monitor/service_monitor.yaml
 	- kubectl delete -f deploy/monitor/operator_service.yaml
+	- kubectl delete -f deploy/monitor/mss_service_monitor.yaml
 	- kubectl delete -f deploy/monitor/prometheus-rule.yaml
 	- kubectl delete -f deploy/monitor/grafana-dashboard.yaml
 

--- a/README.adoc
+++ b/README.adoc
@@ -213,7 +213,7 @@ Environment Variables are used to configure the https://github.com/aerogear/mobi
 
 The application-monitoring stack provisioned by the
 https://github.com/integr8ly/application-monitoring-operator[application-monitoring-operator] on https://github.com/integr8ly[Integr8ly]
-can be used to gather metrics from this operator. These metrics can be used by Integr8ly's application monitoring to generate Prometheus metrics, AlertManager alerts and a Grafana dashboard.
+can be used to gather metrics from this operator and the mobile security service. These metrics can be used by Integr8ly's application monitoring to generate Prometheus metrics, AlertManager alerts and a Grafana dashboard.
 
 It is required that the https://github.com/integr8ly/grafana-operator[integr8ly/Grafana] and https://github.com/coreos/prometheus-operator[Prometheus] operators are installed. For further detail see https://github.com/integr8ly/application-monitoring-operator[integr8ly/application-monitoring-operator].
 
@@ -235,10 +235,11 @@ $ oc project mobile-security-service
 
 [source,shell]
 ----
-# Installation of ServiceMonitor
+# Installation of ServiceMonitor for Operator and Mobile-Security-Service
 
 $ kubectl label namespace mobile-security-service monitoring-key=middleware
 $ kubectl create -f deploy/monitor/service_monitor.yaml
+$ kubectl create -f deploy/monitor/mss_service_monitor.yaml
 $ kubectl create -f deploy/monitor/operator_service.yaml
 ----
 

--- a/deploy/monitor/mss_service_monitor.yaml
+++ b/deploy/monitor/mss_service_monitor.yaml
@@ -4,11 +4,11 @@ kind: ServiceMonitor
 metadata:
   labels:
     monitoring-key: middleware
-  name: mobile-security-service-operator
+  name: mobile-security-service
 spec:
   endpoints:
-    - path: /metrics
-      port: metrics
+    - path: /api/metrics
+      port: server
   selector:
     matchLabels:
-      name: mobile-security-service-operator
+      app: mobilesecurityservice


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/INTLY-1892

## What
Add mobile security service metrics to Prometheus

## Why
Required to created alerts and dashboards

## How
Add a Prometheus ServiceMonitor

## Verification Steps
- Its deployed here
https://prometheus-route-middleware-monitoring.apps.austin-3e02.openshiftworkshop.com/graph
- Check the following metrics exist 
  - go_gc_duration_seconds{job="mobile-security-service-application"}
  - go_gc_duration_seconds_count{job="mobile-security-service-application"}
  - go_gc_duration_seconds_sum{job="mobile-security-service-application"}
  - promhttp_metric_handler_requests_in_flight{job="mobile-security-service-application"}
  - promhttp_metric_handler_requests_total{job="mobile-security-service-application"}

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

 