### PR TITLE
fix(url): removed `/init` from URL

### DIFF
--- a/pkg/controller/mobilesecurityserviceapp/controller.go
+++ b/pkg/controller/mobilesecurityserviceapp/controller.go
@@ -210,13 +210,13 @@ func (r *ReconcileMobileSecurityServiceApp) Reconcile(request reconcile.Request)
 		return reconcile.Result{}, err
 	}
 
-	// Get the Public Service API URL which will be used to build the SDKConfigMap json
-	publicServiceURLAPI := utils.GetInitPublicURL(route, mss)
+	// Get the Public URL which will be used to build the SDKConfigMap json
+	apiURL := utils.GetPublicURL(route, mss)
 
 	reqLogger.Info("Checking if the configMap already exists ...")
 	// Check if ConfigMap for the app exist, if not create one.
 	if _, err := r.fetchConfigMap(reqLogger, mssApp); err != nil {
-		if err := r.create(mssApp, ConfigMap, publicServiceURLAPI, reqLogger, request); err != nil {
+		if err := r.create(mssApp, ConfigMap, apiURL, reqLogger, request); err != nil {
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,7 +20,6 @@ const (
 	OperatorNamespaceForLocalEnv   = "mobile-security-service"
 	ProxyServiceInstanceName       = "mobile-security-service-proxy"
 	ApplicationServiceInstanceName = "mobile-security-service-application"
-	InitEndpoint                   = "/init"
 	ApiEndpoint                    = "/api"
 	// The MobileSecurityServiceCRName has the name of the CR which should not be changed.
 	MobileSecurityServiceCRName = "mobile-security-service"
@@ -28,9 +27,9 @@ const (
 
 var log = logf.Log.WithName("mobile-security-service-operator.utils")
 
-//GetInitPublicURL returns the public service init endpoint URL for the Rest Service
-func GetInitPublicURL(route *routev1.Route, mss *mobilesecurityservicev1alpha1.MobileSecurityService) string {
-	return fmt.Sprintf("%v://%v%v", mss.Spec.ClusterProtocol, route.Status.Ingress[0].Host, InitEndpoint)
+// GetPublicURL returns the public service URL for the Rest Service
+func GetPublicURL(route *routev1.Route, mss *mobilesecurityservicev1alpha1.MobileSecurityService) string {
+	return fmt.Sprintf("%v://%v", mss.Spec.ClusterProtocol, route.Status.Ingress[0].Host)
 }
 
 //Return REST Service API

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -193,7 +193,7 @@ func TestIsValidOperatorNamespace(t *testing.T) {
 	}
 }
 
-func TestGetInitPublicURL(t *testing.T) {
+func TestGetPublicURL(t *testing.T) {
 	type args struct {
 		instance *mobilesecurityservicev1alpha1.MobileSecurityService
 		route    *routev1.Route
@@ -209,14 +209,14 @@ func TestGetInitPublicURL(t *testing.T) {
 				instance: &mssInstance,
 				route:    &route,
 			},
-			want: "http://testhost/init",
+			want: "http://testhost",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetInitPublicURL(tt.args.route, tt.args.instance)
+			got := GetPublicURL(tt.args.route, tt.args.instance)
 			if got != tt.want {
-				t.Errorf("TestGetInitPublicURL() = %v, want %v", got, tt.want)
+				t.Errorf("TestGetPublicURL() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9486 

## What

Removed `/init` from the URL that is added to the SDKConfig

## Why

This is added by the JS-SDK. 

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Replace the value for `template.spec.containers.image` with `quay.io/ephelan/mobile-security-service-operator:AEROGEAR-9486`
2. Run `make install`.
3. Run `make example-app/apply`.
4. Run `oc get cm example-appname-security -o json`. The value at `data.SDKConfig.url` should be the root URL, without an `/init` amended to it. Like this:

```sh
❯ oc get cm example-appname-security -o json                                                                                                                                 
{                                                                                                                                                                            
    "apiVersion": "v1",                                                                                                                                                      
    "data": {                                                                                                                                                                
        "SDKConfig": "{\n\t\"url\": \"http://route-mobile-security-service.192.168.42.115.nip.io\"\n}"                                                                       
    },
	...                                                                                                                                                                                                                                                                                                                                             
}
```

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
