### PR TITLE
Make HTTPS the default protocol in the MobileSecurityService custom resource

### DIFF
--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
@@ -13,7 +13,7 @@ spec:
 
   size: 1
   # The clusterProtocol is required and used to generated the Public Host URL
-  clusterProtocol: "http" # Options [http or https]
+  clusterProtocol: "https" # Options [http or https]
   configMapName: "mobile-security-service-config"
   routeName: "route"
 


### PR DESCRIPTION
## Motivation

MDC interacts with MSS and expects HTTPS to be used.

## What

Changed value of clusterProtocol from http to https.

## Why

As a developer I expect to use HTTPS. The CR should default to this protocol as it is far more likely to be used. This also means I as a developer do not need to modify the custom resource locally each time the MSS operator has been updated (and the CR is overwritten).

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task