### PR TITLE
refactor: use HTTP for internal API requests (AEROGEAR-9543)

### DIFF
--- a/pkg/service/client.go
+++ b/pkg/service/client.go
@@ -3,11 +3,12 @@ package service
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/aerogear/mobile-security-service/pkg/models"
-	"github.com/go-logr/logr"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/aerogear/mobile-security-service/pkg/models"
+	"github.com/go-logr/logr"
 )
 
 //DeleteAppFromServiceByRestAPI delete the app object in the service

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -20,7 +20,8 @@ const (
 	OperatorNamespaceForLocalEnv   = "mobile-security-service"
 	ProxyServiceInstanceName       = "mobile-security-service-proxy"
 	ApplicationServiceInstanceName = "mobile-security-service-application"
-	ApiEndpoint                    = "/api"
+	APIEndpoint                    = "/api"
+	APIRequestProtocol             = "http"
 	// The MobileSecurityServiceCRName has the name of the CR which should not be changed.
 	MobileSecurityServiceCRName   = "mobile-security-service"
 	MobileSecurityServiceDBCRName = "mobile-security-service-db"
@@ -28,14 +29,14 @@ const (
 
 var log = logf.Log.WithName("mobile-security-service-operator.utils")
 
-// GetPublicURL returns the public service URL for the Rest Service
+// GetPublicURL returns the public service URL for the Service
 func GetPublicURL(route *routev1.Route, mss *mobilesecurityservicev1alpha1.MobileSecurityService) string {
 	return fmt.Sprintf("%v://%v", mss.Spec.ClusterProtocol, route.Status.Ingress[0].Host)
 }
 
 //Return REST Service API
 func GetServiceAPIURL(mss *mobilesecurityservicev1alpha1.MobileSecurityService) string {
-	return mss.Spec.ClusterProtocol + "://" + ApplicationServiceInstanceName + ":" + fmt.Sprint(mss.Spec.Port) + ApiEndpoint
+	return APIRequestProtocol + "://" + ApplicationServiceInstanceName + ":" + fmt.Sprint(mss.Spec.Port) + APIEndpoint
 }
 
 // GetAppNamespaces returns the namespace the operator should be watching for changes


### PR DESCRIPTION
## Motivation

https://issues.jboss.org/browse/AEROGEAR-9543

## What

Make the operator use HTTP for all internal requests to the API.

## Why

If the cluster protocol in the MobileSecurityServiceCR is set to HTTPS then the operator will internally use HTTPS for API requests. This is causing the API requests that are made from the operator to fail and it prevents apps being created or fetched.

## Verification Steps
Add the steps required to check this change. Following an example.
 
1. Update the image in `operator.yaml` to use the one created for verification to be `quay.io/ephelan/mobile-security-service-operator:AEROGEAR-9453`.

2. Ensure that the `clusterProtocol` value is "https" in [mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml](https://github.com/aerogear/mobile-security-service-operator/blob/bbab899a564fce811ac9ef1771b010db55f35913/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml).
2. Run `make install` to install the operator.
3. Run `make example-app/apply`.
4. The app should be created in the database and should appear on the MSS homepage.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 
