### PR TITLE
feat(OpenAPI) : Add schema validation and OpenAPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
       - run:
           name: Install dep
           command: curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+      - run:
+          name: Install operator-sdk to run make setup
+          command: curl -Lo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.8.1/operator-sdk-v0.8.1-x86_64-linux-gnu && chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin/
       - run: make setup
       - run: make code/build/linux
       - run: make test/run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Add schema validation by OpenAPI [PR149](https://github.com/aerogear/mobile-security-service-operator/pull/149)
 
 ## Released 
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -71,17 +71,6 @@
   version = "v1.1.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:72b674cb4faedad73fdb82e7a4d04f40bd2c06b8e75de601f5e6ac4526bb2cb0"
-  name = "github.com/docker/spdystream"
-  packages = [
-    ".",
-    "spdy",
-  ]
-  pruneopts = "NT"
-  revision = "6480d4af844c189cf5dd913db24ddd339d3a4f85"
-
-[[projects]]
   digest = "1:2453249730493850718f891fb40b8f1bc932a0265384fc85b269dc04a01d4673"
   name = "github.com/emicklei/go-restful"
   packages = [
@@ -710,14 +699,11 @@
     "pkg/util/diff",
     "pkg/util/errors",
     "pkg/util/framer",
-    "pkg/util/httpstream",
-    "pkg/util/httpstream/spdy",
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/mergepatch",
     "pkg/util/naming",
     "pkg/util/net",
-    "pkg/util/remotecommand",
     "pkg/util/runtime",
     "pkg/util/sets",
     "pkg/util/strategicpatch",
@@ -729,7 +715,6 @@
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
-    "third_party/forked/golang/netutil",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "NT"
@@ -798,13 +783,10 @@
     "tools/pager",
     "tools/record",
     "tools/reference",
-    "tools/remotecommand",
     "transport",
-    "transport/spdy",
     "util/buffer",
     "util/cert",
     "util/connrotation",
-    "util/exec",
     "util/flowcontrol",
     "util/homedir",
     "util/integer",
@@ -962,6 +944,8 @@
     "github.com/operator-framework/operator-sdk/version",
     "github.com/spf13/pflag",
     "k8s.io/api/apps/v1",
+    "k8s.io/api/batch/v1",
+    "k8s.io/api/batch/v1beta1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/resource",
@@ -974,7 +958,6 @@
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/client-go/rest",
-    "k8s.io/client-go/tools/remotecommand",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",
     "k8s.io/code-generator/cmd/deepcopy-gen",

--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,7 @@ setup/githooks:
 .PHONY: setup
 setup: setup/githooks
 	dep ensure
+	make code/gen
 
 .PHONY: code/run/local
 code/run/local:
@@ -199,6 +200,11 @@ code/vet:
 code/fmt:
 	@echo go fmt
 	go fmt $$(go list ./... | grep -v /vendor/)
+
+.PHONY: code/gen
+code/gen:
+	operator-sdk generate k8s
+	operator-sdk generate openapi
 
 ##############################
 # Tests                      #

--- a/README.adoc
+++ b/README.adoc
@@ -550,6 +550,7 @@ NOTE: The image/tag used from https://github.com/aerogear/mobile-security-servic
 | `make setup/debug`                    | Sets up environment for debugging proposes.
 | `make code/vet`                       | Examines source code and reports suspicious constructs using https://golang.org/cmd/vet/[vet].
 | `make code/fmt`                       | Formats code using https://golang.org/cmd/gofmt/[gofmt].
+| `make code/gen`                       | It will automatically generated/update the files by using the operator-sdk based on the CR status and spec definitions.
 |===
 
 === CI

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebackup_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebackup_cr.yaml
@@ -64,7 +64,7 @@ spec:
   # See here how to create this key : https://help.github.com/en/articles/generating-a-new-gpg-key
 
   # base64 encoded public opengpg cert
-  #cpgPublicKey: "example-cpgPublicKey"
+  #gpgPublicKey: "example-gpgPublicKey"
   #gpgEmail: "email@gmai.com"
   #gpgTrustModel: "always"
 

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebackup_crd.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservicebackup_crd.yaml
@@ -45,7 +45,7 @@ spec:
               type: string
             encryptionKeySecretNamespace:
               type: string
-            cpgPublicKey:
+            gpgPublicKey:
               type: string
             gpgEmail:
               type: string

--- a/deploy/crds/mobilesecurityservice_v1alpha1_mobilesecurityservice_crd.yaml
+++ b/deploy/crds/mobilesecurityservice_v1alpha1_mobilesecurityservice_crd.yaml
@@ -1,0 +1,241 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mobilesecurityservices.mobilesecurityservice.aerogear.com
+spec:
+  group: mobilesecurityservice.aerogear.com
+  names:
+    kind: MobileSecurityService
+    listKind: MobileSecurityServiceList
+    plural: mobilesecurityservices
+    singular: mobilesecurityservice
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            accessControlAllowCredentials:
+              description: 'Value for the Service Environment Variable (ACCESS_CONTROL_ALLOW_CREDENTIALS)
+                More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              type: string
+            accessControlAllowOrigin:
+              description: 'Value for the Service Environment Variable (ACCESS_CONTROL_ALLOW_ORIGIN)
+                More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              type: string
+            clusterProtocol:
+              description: Used to create the URL to allow public access to the Servic
+                Options [http or https].
+              type: string
+            configMapName:
+              description: 'Name of the configMap which will be created to share the
+                data with MobileSecurityServiceDB. Note that by default it is empty
+                and the name will be : MobileSecurityService CR instance Name + -config
+                More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              type: string
+            containerImagePullPolicy:
+              description: 'Policy definition to pull the Service Image More info:
+                https://kubernetes.io/docs/concepts/containers/images/'
+              type: string
+            containerName:
+              description: Name of the container which will be created for the Service
+              type: string
+            databaseHost:
+              description: 'Value for the Service Environment Variable (PGHOST) More
+                info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              type: string
+            databaseName:
+              description: 'Value for the Service Environment Variable (PGDATABASE).
+                This value will be shared to create the database managed by the MobileSecurityServiceDB
+                via a configMap. More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              type: string
+            databasePassword:
+              description: 'Value for the Service Environment Variable (PGPASSWORD).
+                This value will be shared to create the database managed by the MobileSecurityServiceDB
+                via a configMap. More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              type: string
+            databaseUser:
+              description: 'Value for the Service Environment Variable (PGUSER). This
+                value will be shared to create the database managed by the MobileSecurityServiceDB
+                via a configMap. More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              type: string
+            image:
+              description: Service image:tag E.g quay.io/aerogear/mobile-security-service:0.1.0
+              type: string
+            logFormat:
+              description: 'Value for the Service Environment Variable (LOG_FORMAT)
+                More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              type: string
+            logLevel:
+              description: 'Value for the Service Environment Variable (LOG_LEVEL)
+                More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              type: string
+            memoryLimit:
+              description: Limit of Memory which will be available for the Service
+                container
+              type: string
+            memoryRequest:
+              description: Limit of Memory Request which will be available for the
+                Service container
+              type: string
+            oAuthContainerImagePullPolicy:
+              description: 'Policy definition to pull the Oauth Image More info: https://kubernetes.io/docs/concepts/containers/images/'
+              type: string
+            oAuthContainerName:
+              description: Name of the container which will be created for the Service
+                pod as sidecar
+              type: string
+            oAuthImage:
+              description: 'Oauth image:tag E.g docker.io/openshift/oauth-proxy:v1.1.0
+                More info: https://github.com/openshift/oauth-proxy'
+              type: string
+            port:
+              description: 'Value for the Service Environment Variable (PORT) More
+                info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              format: int32
+              type: integer
+            routeName:
+              description: The name of the route which will vbe created to expose
+                the Service
+              type: string
+            size:
+              description: Quantity of instances
+              format: int32
+              type: integer
+          type: object
+        status:
+          properties:
+            appStatus:
+              description: 'Will be as "OK when all objects are created successfully
+                More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            configMapName:
+              description: 'Name of the ConfigMap created and managed by it with the
+                values used in the Service and Database Environment Variables More
+                info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            deploymentName:
+              description: 'Name of the Deployment created and managed by it to provided
+                the Service Application More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            deploymentStatus:
+              description: 'Status of the Deployment created and managed by it to
+                provided the Service Application More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: object
+            proxyServiceName:
+              description: 'Name of the Proxy Service created and managed by it to
+                allow its internal communication with the database. Required because
+                of the Oauth configuration. More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            proxyServiceStatus:
+              description: 'Status of the Proxy Service created and managed by it
+                to allow its internal communication with the database. Required because
+                of the Oauth configuration. More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: object
+            routeName:
+              description: 'Name of the Route object required to expose public the
+                Service Application More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            routeStatus:
+              description: 'Status of the Route object required to expose public the
+                Service Application More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-type'
+              properties:
+                ingress:
+                  description: ingress describes the places where the route may be
+                    exposed. The list of ingress points may contain duplicate Host
+                    or RouterName values. Routes are considered live once they are
+                    `Ready`
+                  items:
+                    properties:
+                      conditions:
+                        description: Conditions is the state of the route, may be
+                          empty.
+                        items:
+                          properties:
+                            lastTransitionTime:
+                              description: RFC 3339 date and time when this condition
+                                last transitioned
+                              format: date-time
+                              type: string
+                            message:
+                              description: Human readable message indicating details
+                                about last transition.
+                              type: string
+                            reason:
+                              description: (brief) reason for the condition's last
+                                transition, and is usually a machine and human readable
+                                constant
+                              type: string
+                            status:
+                              description: Status is the status of the condition.
+                                Can be True, False, Unknown.
+                              type: string
+                            type:
+                              description: Type is the type of the condition. Currently
+                                only Ready.
+                              type: string
+                          required:
+                          - type
+                          - status
+                          type: object
+                        type: array
+                      host:
+                        description: Host is the host string under which the route
+                          is exposed; this value is required
+                        type: string
+                      routerCanonicalHostname:
+                        description: CanonicalHostname is the external host name for
+                          the router that can be used as a CNAME for the host requested
+                          for this route. This value is optional and may not be set
+                          in all cases.
+                        type: string
+                      routerName:
+                        description: Name is a name chosen by the router to identify
+                          itself; this value is required
+                        type: string
+                      wildcardPolicy:
+                        description: Wildcard policy is the wildcard policy that was
+                          allowed where this route is exposed.
+                        type: string
+                    type: object
+                  type: array
+              required:
+              - ingress
+              type: object
+            serviceName:
+              description: 'Name of the Service created and managed by it to expose
+                the Service Application More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            serviceStatus:
+              description: 'Status of the Service created and managed by it to expose
+                the Service Application More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: object
+          required:
+          - configMapName
+          - deploymentName
+          - deploymentStatus
+          - serviceName
+          - serviceStatus
+          - proxyServiceName
+          - proxyServiceStatus
+          - routeName
+          - routeStatus
+          - appStatus
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/crds/mobilesecurityservice_v1alpha1_mobilesecurityserviceapp_crd.yaml
+++ b/deploy/crds/mobilesecurityservice_v1alpha1_mobilesecurityserviceapp_crd.yaml
@@ -1,0 +1,59 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mobilesecurityserviceapps.mobilesecurityservice.aerogear.com
+spec:
+  group: mobilesecurityservice.aerogear.com
+  names:
+    kind: MobileSecurityServiceApp
+    listKind: MobileSecurityServiceAppList
+    plural: mobilesecurityserviceapps
+    singular: mobilesecurityserviceapp
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            appId:
+              description: Unique Identifier for the app which will be created in
+                the Service side
+              type: string
+            appName:
+              description: Name of the app which will be created in the Service side
+              type: string
+          required:
+          - appName
+          - appId
+          type: object
+        status:
+          properties:
+            bindStatus:
+              description: 'Will be as "OK when all objects are created successfully
+                More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            sdkConfigMapName:
+              description: 'Name of the ConfigMap create to share the URL to access
+                the public host of the service More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+          required:
+          - sdkConfigMapName
+          - bindStatus
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/crds/mobilesecurityservice_v1alpha1_mobilesecurityservicebackup_crd.yaml
+++ b/deploy/crds/mobilesecurityservice_v1alpha1_mobilesecurityservicebackup_crd.yaml
@@ -1,0 +1,180 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mobilesecurityservicebackups.mobilesecurityservice.aerogear.com
+spec:
+  group: mobilesecurityservice.aerogear.com
+  names:
+    kind: MobileSecurityServiceBackup
+    listKind: MobileSecurityServiceBackupList
+    plural: mobilesecurityservicebackups
+    singular: mobilesecurityservicebackup
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            awsAccessKeyId:
+              description: 'Key ID of AWS S3 storage. Required to create the Secret
+                with the data to allow send the backup files to AWS S3 storage. More
+                info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service'
+              type: string
+            awsCredentialsSecretName:
+              description: 'Name of the secret with the AWS data credentials already
+                created in the cluster More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service'
+              type: string
+            awsCredentialsSecretNamespace:
+              description: 'Name of the namespace where the scret with the AWS data
+                credentials is in the cluster More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service'
+              type: string
+            awsS3BucketName:
+              description: 'Name of AWS S3 storage. Required to create the Secret
+                with the data to allow send the backup files to AWS S3 storage. More
+                info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service'
+              type: string
+            awsSecretAccessKey:
+              description: 'Secret/Token of AWS S3 storage. Required to create the
+                Secret with the data to allow send the backup files to AWS S3 storage.
+                More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service'
+              type: string
+            databaseVersion:
+              description: 'Database version. (E.g 9.6). IMPORTANT: Just the first
+                2 digits should be used. More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service'
+              type: string
+            encryptionKeySecretName:
+              description: 'Name of the secret with the EncryptionKey data already
+                created in the cluster More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service'
+              type: string
+            encryptionKeySecretNamespace:
+              description: 'Name of the namespace where the secret with the EncryptionKey
+                data is in the cluster More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service'
+              type: string
+            gpgEmail:
+              description: 'GPG email to create the EncryptionKeySecret with this
+                data More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+                See here how to create this key : https://help.github.com/en/articles/generating-a-new-gpg-key'
+              type: string
+            gpgPublicKey:
+              description: 'GPG public key to create the EncryptionKeySecret with
+                this data More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+                See here how to create this key : https://help.github.com/en/articles/generating-a-new-gpg-key'
+              type: string
+            gpgTrustModel:
+              description: 'GPG trust model to create the EncryptionKeySecret with
+                this data. the default value is true when it is empty. More info:
+                https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+                See here how to create this key : https://help.github.com/en/articles/generating-a-new-gpg-key'
+              type: string
+            image:
+              description: 'Image:tag used to do the backup. More Info: https://github.com/integr8ly/backup-container-image'
+              type: string
+            productName:
+              description: 'Used to create the directory where the files will be stored
+                More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service'
+              type: string
+            schedule:
+              description: 'Schedule period for the CronJob  "0 0 * * *" # daily at
+                00:00. More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service'
+              type: string
+          type: object
+        status:
+          properties:
+            awsCredentialsSecretNamespace:
+              description: 'Namespace  of the secret object with the Aws data to allow
+                send the backup files to the AWS storage More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            awsSecretData:
+              additionalProperties:
+                type: string
+              description: 'Data  of the secret object with the Aws data to allow
+                send the backup files to the AWS storage More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: object
+            awsSecretName:
+              description: 'Name  of the secret object with the Aws data to allow
+                send the backup files to the AWS storage More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            backupStatus:
+              description: 'Will be as "OK when all objects are created successfully
+                More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            cronJobName:
+              description: 'Name of the CronJob object created and managed by it to
+                schedule the backup job More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            cronJobStatus:
+              description: 'Status of the CronJob object More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: object
+            databasePodFound:
+              description: 'Boolean value which has true when the Database Pod was
+                found in order to create the secret with the database data to allow
+                the backup image connect into it. More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: boolean
+            databaseServiceFound:
+              description: 'Boolean value which has true when the Service Database
+                Pod was found in order to create the secret with the database data
+                to allow the backup image connect into it. More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: boolean
+            dbSecretData:
+              additionalProperties:
+                type: string
+              description: 'Data  of the secret object created with the database data
+                to allow the backup image connect to the database More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: object
+            dbSecretName:
+              description: 'Name of the secret object created with the database data
+                to allow the backup image connect to the database More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            encryptionKeySecretData:
+              additionalProperties:
+                type: string
+              description: 'Data of the secret object with the Encryption GPG Key
+                More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: object
+            encryptionKeySecretName:
+              description: 'Name  of the secret object with the Encryption GPG Key
+                More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-type'
+              type: string
+            encryptionKeySecretNamespace:
+              description: 'Namespace of the secret object with the Encryption GPG
+                Key More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            hasEncryptionKey:
+              description: 'Boolean value which has true when it has an EncryptionKey
+                to be used to send the backup files More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: boolean
+          required:
+          - backupStatus
+          - cronJobName
+          - dbSecretName
+          - dbSecretData
+          - awsSecretName
+          - awsSecretData
+          - awsCredentialsSecretNamespace
+          - encryptionKeySecretName
+          - encryptionKeySecretNamespace
+          - encryptionKeySecretData
+          - hasEncryptionKey
+          - databasePodFound
+          - databaseServiceFound
+          - cronJobStatus
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/crds/mobilesecurityservice_v1alpha1_mobilesecurityservicedb_crd.yaml
+++ b/deploy/crds/mobilesecurityservice_v1alpha1_mobilesecurityservicedb_crd.yaml
@@ -1,0 +1,131 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mobilesecurityservicedbs.mobilesecurityservice.aerogear.com
+spec:
+  group: mobilesecurityservice.aerogear.com
+  names:
+    kind: MobileSecurityServiceDB
+    listKind: MobileSecurityServiceDBList
+    plural: mobilesecurityservicedbs
+    singular: mobilesecurityservicedb
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            containerImagePullPolicy:
+              description: 'Policy definition to pull the Database Image More info:
+                https://kubernetes.io/docs/concepts/containers/images/'
+              type: string
+            containerName:
+              description: Name to create the Database container
+              type: string
+            databaseMemoryLimit:
+              description: Limit of Memory which will be available for the database
+                container
+              type: string
+            databaseMemoryRequest:
+              description: Limit of Memory Request which will be available for the
+                database container
+              type: string
+            databaseName:
+              description: 'Value for the Database Environment Variable (Spec.DatabaseNameParam).
+                This value will be used when the ConfigMap created by the MobileSecurityService
+                is not found More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              type: string
+            databaseNameParam:
+              description: Key Value for the Database Environment Variable in order
+                to inform the database mame Note that each database version/image
+                can expected a different value for it.
+              type: string
+            databasePassword:
+              description: 'Value for the Database Environment Variable (Spec.DatabasePasswordParam).
+                This value will be used when the ConfigMap created by the MobileSecurityService
+                is not found More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              type: string
+            databasePasswordParam:
+              description: Key Value for the Database Environment Variable in order
+                to inform the database password Note that each database version/image
+                can expected a different value for it.
+              type: string
+            databasePort:
+              description: Value for the Database Environment Variable in order to
+                define the port which it should use. It will be used in its container
+                as well
+              format: int32
+              type: integer
+            databaseStorageRequest:
+              description: Limit of Storage Request which will be available for the
+                database container
+              type: string
+            databaseUser:
+              description: 'Value for the Database Environment Variable (Spec.DatabaseUser).
+                This value will be used when the ConfigMap created by the MobileSecurityService
+                is not found More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
+              type: string
+            databaseUserParam:
+              description: Key Value for the Database Environment Variable in order
+                to inform the database user Note that each database version/image
+                can expected a different value for it.
+              type: string
+            image:
+              description: Database image:tag E.g "centos/postgresql-96-centos7"
+              type: string
+            size:
+              description: Quantity of instances
+              format: int32
+              type: integer
+          type: object
+        status:
+          properties:
+            databaseStatus:
+              description: 'Will be as "OK when all objects are created successfully
+                More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            deploymentName:
+              description: 'Name of the Database Deployment created and managed by
+                it More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            deploymentStatus:
+              description: 'Status of the Database Deployment created and managed
+                by it More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: object
+            persistentVolumeClaimName:
+              description: 'Name of the PersistentVolumeClaim created and managed
+                by it More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            serviceName:
+              description: 'Name of the Database Service created and managed by it
+                More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: string
+            serviceStatus:
+              description: 'Status of the Database Service created and managed by
+                it More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types'
+              type: object
+          required:
+          - persistentVolumeClaimName
+          - deploymentName
+          - deploymentStatus
+          - serviceName
+          - serviceStatus
+          - databaseStatus
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservice_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservice_types.go
@@ -17,32 +17,68 @@ type MobileSecurityServiceSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
-	//Enviroment Variables for the Service
-	DatabaseName                  string `json:"databaseName,omitempty"`
-	DatabasePassword              string `json:"databasePassword,omitempty"`
-	DatabaseUser                  string `json:"databaseUser,omitempty"`
-	DatabaseHost                  string `json:"databaseHost,omitempty"`
-	Port                          int32  `json:"port,omitempty"`
-	LogLevel                      string `json:"logLevel,omitempty"`
-	LogFormat                     string `json:"logFormat,omitempty"`
-	AccessControlAllowOrigin      string `json:"accessControlAllowOrigin"`
-	AccessControlAllowCredentials string `json:"accessControlAllowCredentials"`
+	// Value for the Service Environment Variable (PGDATABASE).
+	// This value will be shared to create the database managed by the MobileSecurityServiceDB via a configMap.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	DatabaseName string `json:"databaseName,omitempty"`
+	// Value for the Service Environment Variable (PGPASSWORD).
+	// This value will be shared to create the database managed by the MobileSecurityServiceDB via a configMap.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	DatabasePassword string `json:"databasePassword,omitempty"`
+	// Value for the Service Environment Variable (PGUSER).
+	// This value will be shared to create the database managed by the MobileSecurityServiceDB via a configMap.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	DatabaseUser string `json:"databaseUser,omitempty"`
+	// Value for the Service Environment Variable (PGHOST)
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	DatabaseHost string `json:"databaseHost,omitempty"`
+	// Value for the Service Environment Variable (LOG_LEVEL)
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	LogLevel string `json:"logLevel,omitempty"`
+	// Value for the Service Environment Variable (LOG_FORMAT)
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	LogFormat string `json:"logFormat,omitempty"`
+	// Value for the Service Environment Variable (ACCESS_CONTROL_ALLOW_ORIGIN)
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	AccessControlAllowOrigin string `json:"accessControlAllowOrigin,omitempty"`
+	// Value for the Service Environment Variable (ACCESS_CONTROL_ALLOW_CREDENTIALS)
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	AccessControlAllowCredentials string `json:"accessControlAllowCredentials,omitempty"`
+	// Value for the Service Environment Variable (PORT)
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	Port int32 `json:"port,omitempty"`
 
-	//CR mandatory configuration values
-	Size               int32  `json:"size,omitempty"`
-	Image              string `json:"image,omitempty"`
-	ContainerName      string `json:"containerName,omitempty"`
-	ClusterProtocol    string `json:"clusterProtocol,omitempty"`
-	MemoryLimit        string `json:"memoryLimit,omitempty"`
-	MemoryRequest      string `json:"memoryRequest,omitempty"`
-	OAuthImage         string `json:"oAuthImage,omitempty"`
+	// Quantity of instances
+	Size int32 `json:"size,omitempty"`
+	// Service image:tag E.g quay.io/aerogear/mobile-security-service:0.1.0
+	Image string `json:"image,omitempty"`
+	// Name of the container which will be created for the Service
+	ContainerName string `json:"containerName,omitempty"`
+	// Used to create the URL to allow public access to the Servic
+	// Options [http or https].
+	ClusterProtocol string `json:"clusterProtocol,omitempty"`
+	// Limit of Memory which will be available for the Service container
+	MemoryLimit string `json:"memoryLimit,omitempty"`
+	// Limit of Memory Request which will be available for the Service container
+	MemoryRequest string `json:"memoryRequest,omitempty"`
+	// Oauth image:tag E.g docker.io/openshift/oauth-proxy:v1.1.0
+	// More info: https://github.com/openshift/oauth-proxy
+	OAuthImage string `json:"oAuthImage,omitempty"`
+	// Name of the container which will be created for the Service pod as sidecar
 	OAuthContainerName string `json:"oAuthContainerName,omitempty"`
 
-	//CR optional configuration values
-	ConfigMapName                 string        `json:"configMapName,omitempty"`
-	RouteName                     string        `json:"routeName,omitempty"`
+	// Name of the configMap which will be created to share the data with MobileSecurityServiceDB.
+	// Note that by default it is empty and the name will be : MobileSecurityService CR instance Name + -config
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	ConfigMapName string `json:"configMapName,omitempty"`
+	// The name of the route which will vbe created to expose the Service
+	RouteName string `json:"routeName,omitempty"`
+	// Policy definition to pull the Oauth Image
+	// More info: https://kubernetes.io/docs/concepts/containers/images/
 	OAuthContainerImagePullPolicy v1.PullPolicy `json:"oAuthContainerImagePullPolicy,omitempty"`
-	ContainerImagePullPolicy      v1.PullPolicy `json:"containerImagePullPolicy,omitempty"`
+	// Policy definition to pull the Service Image
+	// More info: https://kubernetes.io/docs/concepts/containers/images/
+	ContainerImagePullPolicy v1.PullPolicy `json:"containerImagePullPolicy,omitempty"`
 }
 
 // MobileSecurityServiceStatus defines the observed state of MobileSecurityService
@@ -51,16 +87,37 @@ type MobileSecurityServiceStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
-	ConfigMapName      string                   `json:"configMapName"`
-	DeploymentName     string                   `json:"deploymentName"`
-	DeploymentStatus   v1beta1.DeploymentStatus `json:"deploymentStatus"`
-	ServiceName        string                   `json:"serviceName"`
-	ServiceStatus      v1.ServiceStatus         `json:"serviceStatus"`
-	ProxyServiceName   string                   `json:"proxyServiceName"`
-	ProxyServiceStatus v1.ServiceStatus         `json:"proxyServiceStatus"`
-	RouteName          string                   `json:"routeName"`
-	RouteStatus        routev1.RouteStatus      `json:"routeStatus"`
-	AppStatus          string                   `json:"appStatus"`
+
+	// Name of the ConfigMap created and managed by it with the values used in the Service and Database Environment Variables
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	ConfigMapName string `json:"configMapName"`
+	// Name of the Deployment created and managed by it to provided the Service Application
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	DeploymentName string `json:"deploymentName"`
+	// Status of the Deployment created and managed by it to provided the Service Application
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	DeploymentStatus v1beta1.DeploymentStatus `json:"deploymentStatus"`
+	// Name of the Service created and managed by it to expose the Service Application
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	ServiceName string `json:"serviceName"`
+	// Status of the Service created and managed by it to expose the Service Application
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	ServiceStatus v1.ServiceStatus `json:"serviceStatus"`
+	// Name of the Proxy Service created and managed by it to allow its internal communication with the database. Required because of the Oauth configuration.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	ProxyServiceName string `json:"proxyServiceName"`
+	// Status of the Proxy Service created and managed by it to allow its internal communication with the database. Required because of the Oauth configuration.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	ProxyServiceStatus v1.ServiceStatus `json:"proxyServiceStatus"`
+	// Name of the Route object required to expose public the Service Application
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	RouteName string `json:"routeName"`
+	// Status of the Route object required to expose public the Service Application
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-type
+	RouteStatus routev1.RouteStatus `json:"routeStatus"`
+	// Will be as "OK when all objects are created successfully
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	AppStatus string `json:"appStatus"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityserviceapp_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityserviceapp_types.go
@@ -13,8 +13,11 @@ type MobileSecurityServiceAppSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+
+	// Name of the app which will be created in the Service side
 	AppName string `json:"appName"`
-	AppId   string `json:"appId"`
+	// Unique Identifier for the app which will be created in the Service side
+	AppId string `json:"appId"`
 }
 
 // MobileSecurityServiceAppStatus defines the observed state of MobileSecurityServiceApp
@@ -23,8 +26,13 @@ type MobileSecurityServiceAppStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+
+	// Name of the ConfigMap create to share the URL to access the public host of the service
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
 	SDKConfigMapName string `json:"sdkConfigMapName"`
-	BindStatus       string `json:"bindStatus"`
+	// Will be as "OK when all objects are created successfully
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	BindStatus string `json:"bindStatus"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservicebackup_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservicebackup_types.go
@@ -14,22 +14,68 @@ type MobileSecurityServiceBackupSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
-	Schedule        string `json:"schedule,omitempty"`
-	Image           string `json:"image,omitempty"`
-	DatabaseVersion string `json:"databaseVersion,omitempty"`
-	ProductName     string `json:"productName,omitempty"`
 
-	AwsS3BucketName               string `json:"awsS3BucketName,omitempty"`
-	AwsAccessKeyId                string `json:"awsAccessKeyId,omitempty"`
-	AwsSecretAccessKey            string `json:"awsSecretAccessKey,omitempty"`
-	AwsCredentialsSecretName      string `json:"awsCredentialsSecretName,omitempty"`
+	// Schedule period for the CronJob  "0 0 * * *" # daily at 00:00.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+	Schedule string `json:"schedule,omitempty"`
+
+	// Image:tag used to do the backup.
+	// More Info: https://github.com/integr8ly/backup-container-image
+	Image string `json:"image,omitempty"`
+
+	// Database version. (E.g 9.6).
+	// IMPORTANT: Just the first 2 digits should be used.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+	DatabaseVersion string `json:"databaseVersion,omitempty"`
+
+	// Used to create the directory where the files will be stored
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+	ProductName string `json:"productName,omitempty"`
+
+	// Name of AWS S3 storage.
+	// Required to create the Secret with the data to allow send the backup files to AWS S3 storage.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+	AwsS3BucketName string `json:"awsS3BucketName,omitempty"`
+
+	// Key ID of AWS S3 storage.
+	// Required to create the Secret with the data to allow send the backup files to AWS S3 storage.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+	AwsAccessKeyId string `json:"awsAccessKeyId,omitempty"`
+
+	// Secret/Token of AWS S3 storage.
+	// Required to create the Secret with the data to allow send the backup files to AWS S3 storage.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+	AwsSecretAccessKey string `json:"awsSecretAccessKey,omitempty"`
+
+	// Name of the secret with the AWS data credentials already created in the cluster
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+	AwsCredentialsSecretName string `json:"awsCredentialsSecretName,omitempty"`
+	// Name of the namespace where the scret with the AWS data credentials is in the cluster
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
 	AwsCredentialsSecretNamespace string `json:"awsCredentialsSecretNamespace,omitempty"`
 
-	EncryptionKeySecretName      string `json:"encryptionKeySecretName,omitempty"`
+	// Name of the secret with the EncryptionKey data already created in the cluster
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+	EncryptionKeySecretName string `json:"encryptionKeySecretName,omitempty"`
+
+	// Name of the namespace where the secret with the EncryptionKey data is in the cluster
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
 	EncryptionKeySecretNamespace string `json:"encryptionKeySecretNamespace,omitempty"`
-	GpgPublicKey                 string `json:"cpgPublicKey,omitempty"`
-	GpgEmail                     string `json:"gpgEmail,omitempty"`
-	GpgTrustModel                string `json:"gpgTrustModel,omitempty"`
+
+	// GPG public key to create the EncryptionKeySecret with this data
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+	// See here how to create this key : https://help.github.com/en/articles/generating-a-new-gpg-key
+	GpgPublicKey string `json:"gpgPublicKey,omitempty"`
+
+	// GPG email to create the EncryptionKeySecret with this data
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+	// See here how to create this key : https://help.github.com/en/articles/generating-a-new-gpg-key
+	GpgEmail string `json:"gpgEmail,omitempty"`
+
+	// GPG trust model to create the EncryptionKeySecret with this data. the default value is true when it is empty.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service
+	// See here how to create this key : https://help.github.com/en/articles/generating-a-new-gpg-key
+	GpgTrustModel string `json:"gpgTrustModel,omitempty"`
 }
 
 // MobileSecurityServiceBackupStatus defines the observed state of MobileSecurityServiceBackup
@@ -37,21 +83,50 @@ type MobileSecurityServiceBackupSpec struct {
 type MobileSecurityServiceBackupStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
-	BackupStatus                  string                `json:"backupStatus"`
-	CronJobName                   string                `json:"cronJobName"`
-	DBSecretName                  string                `json:"dbSecretName"`
-	DBSecretData                  map[string]string     `json:"dbSecretData"`
-	AWSSecretName                 string                `json:"awsSecretName"`
-	AWSSecretData                 map[string]string     `json:"awsSecretData"`
-	AwsCredentialsSecretNamespace string                `json:"awsCredentialsSecretNamespace"`
-	EncryptionKeySecretName       string                `json:"encryptionKeySecretName"`
-	EncryptionKeySecretNamespace  string                `json:"encryptionKeySecretNamespace"`
-	EncryptionKeySecretData       map[string]string     `json:"encryptionKeySecretData"`
-	HasEncryptionKey              bool                  `json:"hasEncryptionKey"`
-	DatabasePodFound              bool                  `json:"databasePodFound"`
-	DatabaseServiceFound          bool                  `json:"databaseServiceFound"`
-	CronJobStatus                 v1beta1.CronJobStatus `json:"cronJobStatus"`
+	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.htm
+
+	// Will be as "OK when all objects are created successfully
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	BackupStatus string `json:"backupStatus"`
+	// Name of the CronJob object created and managed by it to schedule the backup job
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	CronJobName string `json:"cronJobName"`
+	// Name of the secret object created with the database data to allow the backup image connect to the database
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	DBSecretName string `json:"dbSecretName"`
+	// Data  of the secret object created with the database data to allow the backup image connect to the database
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	DBSecretData map[string]string `json:"dbSecretData"`
+	// Name  of the secret object with the Aws data to allow send the backup files to the AWS storage
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	AWSSecretName string `json:"awsSecretName"`
+	// Data  of the secret object with the Aws data to allow send the backup files to the AWS storage
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	AWSSecretData map[string]string `json:"awsSecretData"`
+	// Namespace  of the secret object with the Aws data to allow send the backup files to the AWS storage
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	AwsCredentialsSecretNamespace string `json:"awsCredentialsSecretNamespace"`
+	// Name  of the secret object with the Encryption GPG Key
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-type
+	EncryptionKeySecretName string `json:"encryptionKeySecretName"`
+	// Namespace of the secret object with the Encryption GPG Key
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	EncryptionKeySecretNamespace string `json:"encryptionKeySecretNamespace"`
+	// Data of the secret object with the Encryption GPG Key
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	EncryptionKeySecretData map[string]string `json:"encryptionKeySecretData"`
+	// Boolean value which has true when it has an EncryptionKey to be used to send the backup files
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	HasEncryptionKey bool `json:"hasEncryptionKey"`
+	// Boolean value which has true when the Database Pod was found in order to create the secret with the database data to allow the backup image connect into it.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	DatabasePodFound bool `json:"databasePodFound"`
+	// Boolean value which has true when the Service Database Pod was found in order to create the secret with the database data to allow the backup image connect into it.
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	DatabaseServiceFound bool `json:"databaseServiceFound"`
+	// Status of the CronJob object
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	CronJobStatus v1beta1.CronJobStatus `json:"cronJobStatus"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservicedb_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservicedb_types.go
@@ -16,24 +16,51 @@ type MobileSecurityServiceDBSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 
-	//Enviroment Variables for the DB when the Service configMap was not found
-	DatabaseName          string `json:"databaseName,omitempty"`
-	DatabasePassword      string `json:"databasePassword,omitempty"`
-	DatabaseUser          string `json:"databaseUser,omitempty"`
-	DatabaseNameParam     string `json:"databaseNameParam,omitempty"`
-	DatabasePasswordParam string `json:"databasePasswordParam,omitempty"`
-	DatabaseUserParam     string `json:"databaseUserParam,omitempty"`
-	DatabasePort          int32  `json:"databasePort,omitempty"`
+	// Value for the Database Environment Variable (Spec.DatabaseNameParam).
+	// This value will be used when the ConfigMap created by the MobileSecurityService is not found
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	DatabaseName string `json:"databaseName,omitempty"`
 
-	//CR mandatory config values
-	Size                   int32  `json:"size,omitempty"`
-	Image                  string `json:"image,omitempty"`
-	ContainerName          string `json:"containerName,omitempty"`
-	DatabaseMemoryLimit    string `json:"databaseMemoryLimit,omitempty"`
-	DatabaseMemoryRequest  string `json:"databaseMemoryRequest,omitempty"`
+	// Value for the Database Environment Variable (Spec.DatabasePasswordParam).
+	// This value will be used when the ConfigMap created by the MobileSecurityService is not found
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	DatabasePassword string `json:"databasePassword,omitempty"`
+
+	// Value for the Database Environment Variable (Spec.DatabaseUser).
+	// This value will be used when the ConfigMap created by the MobileSecurityService is not found
+	// More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values
+	DatabaseUser string `json:"databaseUser,omitempty"`
+
+	// Key Value for the Database Environment Variable in order to inform the database mame
+	// Note that each database version/image can expected a different value for it.
+	DatabaseNameParam string `json:"databaseNameParam,omitempty"`
+
+	// Key Value for the Database Environment Variable in order to inform the database password
+	// Note that each database version/image can expected a different value for it.
+	DatabasePasswordParam string `json:"databasePasswordParam,omitempty"`
+
+	// Key Value for the Database Environment Variable in order to inform the database user
+	// Note that each database version/image can expected a different value for it.
+	DatabaseUserParam string `json:"databaseUserParam,omitempty"`
+
+	// Value for the Database Environment Variable in order to define the port which it should use. It will be used in its container as well
+	DatabasePort int32 `json:"databasePort,omitempty"`
+
+	// Quantity of instances
+	Size int32 `json:"size,omitempty"`
+	// Database image:tag E.g "centos/postgresql-96-centos7"
+	Image string `json:"image,omitempty"`
+	// Name to create the Database container
+	ContainerName string `json:"containerName,omitempty"`
+	// Limit of Memory which will be available for the database container
+	DatabaseMemoryLimit string `json:"databaseMemoryLimit,omitempty"`
+	// Limit of Memory Request which will be available for the database container
+	DatabaseMemoryRequest string `json:"databaseMemoryRequest,omitempty"`
+	// Limit of Storage Request which will be available for the database container
 	DatabaseStorageRequest string `json:"databaseStorageRequest,omitempty"`
 
-	//CR optinal config values
+	// Policy definition to pull the Database Image
+	// More info: https://kubernetes.io/docs/concepts/containers/images/
 	ContainerImagePullPolicy v1.PullPolicy `json:"containerImagePullPolicy,omitempty"`
 }
 
@@ -43,12 +70,25 @@ type MobileSecurityServiceDBStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
-	PersistentVolumeClaimName string                   `json:"persistentVolumeClaimName"`
-	DeploymentName            string                   `json:"deploymentName"`
-	DeploymentStatus          v1beta1.DeploymentStatus `json:"deploymentStatus"`
-	ServiceName               string                   `json:"serviceName"`
-	ServiceStatus             v1.ServiceStatus         `json:"serviceStatus"`
-	DatabaseStatus            string                   `json:"databaseStatus"`
+
+	// Name of the PersistentVolumeClaim created and managed by it
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	PersistentVolumeClaimName string `json:"persistentVolumeClaimName"`
+	// Name of the Database Deployment created and managed by it
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	DeploymentName string `json:"deploymentName"`
+	// Status of the Database Deployment created and managed by it
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	DeploymentStatus v1beta1.DeploymentStatus `json:"deploymentStatus"`
+	// Name of the Database Service created and managed by it
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	ServiceName string `json:"serviceName"`
+	// Status of the Database Service created and managed by it
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	ServiceStatus v1.ServiceStatus `json:"serviceStatus"`
+	// Will be as "OK when all objects are created successfully
+	// More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types
+	DatabaseStatus string `json:"databaseStatus"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/mobilesecurityservice/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/zz_generated.openapi.go
@@ -13,12 +13,18 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityService":         schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityService(ref),
-		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceDB":       schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceDB(ref),
-		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceDBSpec":   schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceDBSpec(ref),
-		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceDBStatus": schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceDBStatus(ref),
-		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceSpec":     schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceSpec(ref),
-		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceStatus":   schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceStatus(ref),
+		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityService":             schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityService(ref),
+		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceApp":          schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceApp(ref),
+		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceAppSpec":      schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceAppSpec(ref),
+		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceAppStatus":    schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceAppStatus(ref),
+		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceBackup":       schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceBackup(ref),
+		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceBackupSpec":   schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceBackupSpec(ref),
+		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceBackupStatus": schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceBackupStatus(ref),
+		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceDB":           schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceDB(ref),
+		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceDBSpec":       schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceDBSpec(ref),
+		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceDBStatus":     schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceDBStatus(ref),
+		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceSpec":         schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceSpec(ref),
+		"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceStatus":       schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceStatus(ref),
 	}
 }
 
@@ -62,6 +68,392 @@ func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityService(ref co
 		},
 		Dependencies: []string{
 			"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceSpec", "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+	}
+}
+
+func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceApp(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "MobileSecurityServiceApp is the Schema for the mobilesecurityserviceapps API",
+				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceAppSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceAppStatus"),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceAppSpec", "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceAppStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+	}
+}
+
+func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceAppSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "MobileSecurityServiceAppSpec defines the desired state of MobileSecurityServiceApp",
+				Properties: map[string]spec.Schema{
+					"appName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the app which will be created in the Service side",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"appId": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Unique Identifier for the app which will be created in the Service side",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"appName", "appId"},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceAppStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "MobileSecurityServiceAppStatus defines the observed state of MobileSecurityServiceApp",
+				Properties: map[string]spec.Schema{
+					"sdkConfigMapName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the ConfigMap create to share the URL to access the public host of the service More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"bindStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Will be as \"OK when all objects are created successfully More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"sdkConfigMapName", "bindStatus"},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceBackup(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "MobileSecurityServiceBackup is the Schema for the mobilesecurityservicedbbackups API",
+				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceBackupSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceBackupStatus"),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceBackupSpec", "github.com/aerogear/mobile-security-service-operator/pkg/apis/mobilesecurityservice/v1alpha1.MobileSecurityServiceBackupStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+	}
+}
+
+func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceBackupSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "MobileSecurityServiceBackupSpec defines the desired state of MobileSecurityServiceBackup",
+				Properties: map[string]spec.Schema{
+					"schedule": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Schedule period for the CronJob  \"0 0 * * *\" # daily at 00:00. More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"image": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Image:tag used to do the backup. More Info: https://github.com/integr8ly/backup-container-image",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"databaseVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Database version. (E.g 9.6). IMPORTANT: Just the first 2 digits should be used. More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"productName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Used to create the directory where the files will be stored More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"awsS3BucketName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of AWS S3 storage. Required to create the Secret with the data to allow send the backup files to AWS S3 storage. More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"awsAccessKeyId": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Key ID of AWS S3 storage. Required to create the Secret with the data to allow send the backup files to AWS S3 storage. More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"awsSecretAccessKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Secret/Token of AWS S3 storage. Required to create the Secret with the data to allow send the backup files to AWS S3 storage. More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"awsCredentialsSecretName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the secret with the AWS data credentials already created in the cluster More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"awsCredentialsSecretNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the namespace where the scret with the AWS data credentials is in the cluster More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"encryptionKeySecretName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the secret with the EncryptionKey data already created in the cluster More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"encryptionKeySecretNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the namespace where the secret with the EncryptionKey data is in the cluster More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"gpgPublicKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GPG public key to create the EncryptionKeySecret with this data More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service See here how to create this key : https://help.github.com/en/articles/generating-a-new-gpg-key",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"gpgEmail": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GPG email to create the EncryptionKeySecret with this data More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service See here how to create this key : https://help.github.com/en/articles/generating-a-new-gpg-key",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"gpgTrustModel": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GPG trust model to create the EncryptionKeySecret with this data. the default value is true when it is empty. More info: https://github.com/aerogear/mobile-security-service-operator#configuring-the-backup-service See here how to create this key : https://help.github.com/en/articles/generating-a-new-gpg-key",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceBackupStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "MobileSecurityServiceBackupStatus defines the observed state of MobileSecurityServiceBackup",
+				Properties: map[string]spec.Schema{
+					"backupStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Will be as \"OK when all objects are created successfully More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"cronJobName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the CronJob object created and managed by it to schedule the backup job More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"dbSecretName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the secret object created with the database data to allow the backup image connect to the database More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"dbSecretData": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Data  of the secret object created with the database data to allow the backup image connect to the database More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"awsSecretName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name  of the secret object with the Aws data to allow send the backup files to the AWS storage More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"awsSecretData": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Data  of the secret object with the Aws data to allow send the backup files to the AWS storage More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"awsCredentialsSecretNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace  of the secret object with the Aws data to allow send the backup files to the AWS storage More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"encryptionKeySecretName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name  of the secret object with the Encryption GPG Key More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-type",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"encryptionKeySecretNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace of the secret object with the Encryption GPG Key More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"encryptionKeySecretData": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Data of the secret object with the Encryption GPG Key More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"hasEncryptionKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Boolean value which has true when it has an EncryptionKey to be used to send the backup files More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"databasePodFound": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Boolean value which has true when the Database Pod was found in order to create the secret with the database data to allow the backup image connect into it. More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"databaseServiceFound": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Boolean value which has true when the Service Database Pod was found in order to create the secret with the database data to allow the backup image connect into it. More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"cronJobStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the CronJob object More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Ref:         ref("k8s.io/api/batch/v1beta1.CronJobStatus"),
+						},
+					},
+				},
+				Required: []string{"backupStatus", "cronJobName", "dbSecretName", "dbSecretData", "awsSecretName", "awsSecretData", "awsCredentialsSecretNamespace", "encryptionKeySecretName", "encryptionKeySecretNamespace", "encryptionKeySecretData", "hasEncryptionKey", "databasePodFound", "databaseServiceFound", "cronJobStatus"},
+			},
+		},
+		Dependencies: []string{
+			"k8s.io/api/batch/v1beta1.CronJobStatus"},
 	}
 }
 
@@ -114,75 +506,105 @@ func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceDBSpec(
 			SchemaProps: spec.SchemaProps{
 				Description: "MobileSecurityServiceDBSpec defines the desired state of MobileSecurityServiceDB",
 				Properties: map[string]spec.Schema{
+					"databaseName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Database Environment Variable (Spec.DatabaseNameParam). This value will be used when the ConfigMap created by the MobileSecurityService is not found More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"databasePassword": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Database Environment Variable (Spec.DatabasePasswordParam). This value will be used when the ConfigMap created by the MobileSecurityService is not found More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"databaseUser": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Database Environment Variable (Spec.DatabaseUser). This value will be used when the ConfigMap created by the MobileSecurityService is not found More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"databaseNameParam": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Key Value for the Database Environment Variable in order to inform the database mame Note that each database version/image can expected a different value for it.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"databasePasswordParam": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Key Value for the Database Environment Variable in order to inform the database password Note that each database version/image can expected a different value for it.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"databaseUserParam": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Key Value for the Database Environment Variable in order to inform the database user Note that each database version/image can expected a different value for it.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"databasePort": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Database Environment Variable in order to define the port which it should use. It will be used in its container as well",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"size": {
 						SchemaProps: spec.SchemaProps{
-							Description: "INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html",
+							Description: "Quantity of instances",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Database image:tag E.g \"centos/postgresql-96-centos7\"",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"containerName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"databaseName": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"databasePassword": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"databaseUser": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"databasePort": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "Name to create the Database container",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"databaseMemoryLimit": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Limit of Memory which will be available for the database container",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"databaseMemoryRequest": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Limit of Memory Request which will be available for the database container",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"databaseStorageRequest": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Limit of Storage Request which will be available for the database container",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
-					"configMapName": {
+					"containerImagePullPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Policy definition to pull the Database Image More info: https://kubernetes.io/docs/concepts/containers/images/",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
-				Required: []string{"size", "image", "containerName", "databaseName", "databasePassword", "databaseUser", "databasePort", "databaseMemoryLimit", "databaseMemoryRequest", "databaseStorageRequest"},
 			},
 		},
 		Dependencies: []string{},
@@ -195,25 +617,52 @@ func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceDBStatu
 			SchemaProps: spec.SchemaProps{
 				Description: "MobileSecurityServiceDBStatus defines the observed state of MobileSecurityServiceDB",
 				Properties: map[string]spec.Schema{
-					"nodes": {
+					"persistentVolumeClaimName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
-									},
-								},
-							},
+							Description: "Name of the PersistentVolumeClaim created and managed by it More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"deploymentName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the Database Deployment created and managed by it More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"deploymentStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the Database Deployment created and managed by it More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Ref:         ref("k8s.io/api/extensions/v1beta1.DeploymentStatus"),
+						},
+					},
+					"serviceName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the Database Service created and managed by it More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"serviceStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the Database Service created and managed by it More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Ref:         ref("k8s.io/api/core/v1.ServiceStatus"),
+						},
+					},
+					"databaseStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Will be as \"OK when all objects are created successfully More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
-				Required: []string{"nodes"},
+				Required: []string{"persistentVolumeClaimName", "deploymentName", "deploymentStatus", "serviceName", "serviceStatus", "databaseStatus"},
 			},
 		},
-		Dependencies: []string{},
+		Dependencies: []string{
+			"k8s.io/api/core/v1.ServiceStatus", "k8s.io/api/extensions/v1beta1.DeploymentStatus"},
 	}
 }
 
@@ -223,117 +672,154 @@ func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceSpec(re
 			SchemaProps: spec.SchemaProps{
 				Description: "MobileSecurityServiceSpec defines the desired state of MobileSecurityService",
 				Properties: map[string]spec.Schema{
+					"databaseName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Service Environment Variable (PGDATABASE). This value will be shared to create the database managed by the MobileSecurityServiceDB via a configMap. More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"databasePassword": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Service Environment Variable (PGPASSWORD). This value will be shared to create the database managed by the MobileSecurityServiceDB via a configMap. More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"databaseUser": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Service Environment Variable (PGUSER). This value will be shared to create the database managed by the MobileSecurityServiceDB via a configMap. More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"databaseHost": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Service Environment Variable (PGHOST) More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"logLevel": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Service Environment Variable (LOG_LEVEL) More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"logFormat": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Service Environment Variable (LOG_FORMAT) More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"accessControlAllowOrigin": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Service Environment Variable (ACCESS_CONTROL_ALLOW_ORIGIN) More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"accessControlAllowCredentials": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Service Environment Variable (ACCESS_CONTROL_ALLOW_CREDENTIALS) More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"port": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Value for the Service Environment Variable (PORT) More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"size": {
 						SchemaProps: spec.SchemaProps{
-							Description: "INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html",
+							Description: "Quantity of instances",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Service image:tag E.g quay.io/aerogear/mobile-security-service:0.1.0",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"containerName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Name of the container which will be created for the Service",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
-					"databaseName": {
+					"clusterProtocol": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"databasePassword": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"databaseUser": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"databaseHost": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Used to create the URL to allow public access to the Servic Options [http or https].",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"memoryLimit": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Limit of Memory which will be available for the Service container",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"memoryRequest": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Limit of Memory Request which will be available for the Service container",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
-					"port": {
+					"oAuthImage": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "Oauth image:tag E.g docker.io/openshift/oauth-proxy:v1.1.0 More info: https://github.com/openshift/oauth-proxy",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
-					"logLevel": {
+					"oAuthContainerName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"logFormat": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"accessControlAllowOrigin": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"accessControlAllowCredentials": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"clusterHost": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"hostSufix": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"protocol": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Name of the container which will be created for the Service pod as sidecar",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"configMapName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Name of the configMap which will be created to share the data with MobileSecurityServiceDB. Note that by default it is empty and the name will be : MobileSecurityService CR instance Name + -config More info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"routeName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The name of the route which will vbe created to expose the Service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"oAuthContainerImagePullPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Policy definition to pull the Oauth Image More info: https://kubernetes.io/docs/concepts/containers/images/",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"containerImagePullPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Policy definition to pull the Service Image More info: https://kubernetes.io/docs/concepts/containers/images/",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
-				Required: []string{"size", "image", "containerName", "databaseName", "databasePassword", "databaseUser", "databaseHost", "memoryLimit", "memoryRequest", "accessControlAllowOrigin", "accessControlAllowCredentials", "clusterHost", "hostSufix", "protocol"},
 			},
 		},
 		Dependencies: []string{},
@@ -346,24 +832,77 @@ func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceStatus(
 			SchemaProps: spec.SchemaProps{
 				Description: "MobileSecurityServiceStatus defines the observed state of MobileSecurityService",
 				Properties: map[string]spec.Schema{
-					"nodes": {
+					"configMapName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
-									},
-								},
-							},
+							Description: "Name of the ConfigMap created and managed by it with the values used in the Service and Database Environment Variables More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"deploymentName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the Deployment created and managed by it to provided the Service Application More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"deploymentStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the Deployment created and managed by it to provided the Service Application More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Ref:         ref("k8s.io/api/extensions/v1beta1.DeploymentStatus"),
+						},
+					},
+					"serviceName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the Service created and managed by it to expose the Service Application More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"serviceStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the Service created and managed by it to expose the Service Application More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Ref:         ref("k8s.io/api/core/v1.ServiceStatus"),
+						},
+					},
+					"proxyServiceName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the Proxy Service created and managed by it to allow its internal communication with the database. Required because of the Oauth configuration. More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"proxyServiceStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the Proxy Service created and managed by it to allow its internal communication with the database. Required because of the Oauth configuration. More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Ref:         ref("k8s.io/api/core/v1.ServiceStatus"),
+						},
+					},
+					"routeName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the Route object required to expose public the Service Application More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"routeStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the Route object required to expose public the Service Application More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-type",
+							Ref:         ref("github.com/openshift/api/route/v1.RouteStatus"),
+						},
+					},
+					"appStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Will be as \"OK when all objects are created successfully More info: https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 				},
-				Required: []string{"nodes"},
+				Required: []string{"configMapName", "deploymentName", "deploymentStatus", "serviceName", "serviceStatus", "proxyServiceName", "proxyServiceStatus", "routeName", "routeStatus", "appStatus"},
 			},
 		},
-		Dependencies: []string{},
+		Dependencies: []string{
+			"github.com/openshift/api/route/v1.RouteStatus", "k8s.io/api/core/v1.ServiceStatus", "k8s.io/api/extensions/v1beta1.DeploymentStatus"},
 	}
 }

--- a/pkg/controller/mobilesecurityservice/helpers.go
+++ b/pkg/controller/mobilesecurityservice/helpers.go
@@ -49,6 +49,7 @@ func getAppEnvVarsMap(mss *mobilesecurityservicev1alpha1.MobileSecurityService) 
 		"PGDATABASE":                       mss.Spec.DatabaseName,
 		"PGPASSWORD":                       mss.Spec.DatabasePassword,
 		"PGUSER":                           mss.Spec.DatabaseUser,
+		"PORT":                             string(mss.Spec.Port),
 	}
 }
 


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9507

## What
- Add OpenAPI Schema and definitions

## Why
- It will make easier create the OLM
- Following the good practices
- Make easier the understatement
- Validate the data in the CR by the API

## Verification Steps
* Check the CI
* Run the command `make setup` which will call the make code/gen which updates the files automatically.  

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

 ## Extra

* if you wish you can test the operator again besides not be required since no impacts it should have. The image is: `docker.io/cmacedo/mobile-security-service-operator:openAPI`

* If you wish you can check how this validation works as follows. 

```yaml
apiVersion: mobile-security-service.aerogear.com/v1alpha1
kind: MobileSecurityService
metadata:
  name: mobile-security-service
spec:
   routeName: 1 # It will not be applied because there is expected a string
```

