### PR TITLE
Fix prometheus rules and improve/fix the SOP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Add schema validation by OpenAPI [PR149](https://github.com/aerogear/mobile-security-service-operator/pull/149)
+- Fix Prometheus Rules for MobileSecurityServicePodCount and MobileSecurityServiceDown [#151](https://github.com/aerogear/mobile-security-service-operator/pull/151)
+- Improve and fix sop in order to add steps to scale the pod [#151](https://github.com/aerogear/mobile-security-service-operator/pull/151)
+- Add schema validation by OpenAPI [#149](https://github.com/aerogear/mobile-security-service-operator/pull/149)
 
 ## Released 
 

--- a/SOP/SOP-mss.adoc
+++ b/SOP/SOP-mss.adoc
@@ -20,28 +20,59 @@ toc::[]
 
 === MobileSecurityServiceConsoleDown or MobileSecurityServiceDown
 
-. Check that the Mobile Security Service CR is deployed in the same namespace as the operator by running `oc get MobileSecurityService`
+. Check that the Mobile Security Service CR is deployed in the same namespace as the operator by running `oc get MobileSecurityService`. Following an expected result.
++
+[source,shell]
+----
+$ oc get MobileSecurityService
+NAME                      AGE
+mobile-security-service   7d
+----
++
+NOTE: The MobileSecurityService need to be applied in order to allow the operator be able to create/manage the MSS Service pod.
++
 . Check the status of the Mobile Security Service CR by running `oc describe MobileSecurityService`
 +
 NOTE: Check that the status are as expected as described in the https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types[Status Definitions per Types in the README]
 +
+IMPORTANT: By the CR status you are able to identify what is missing as it is an important information to be send to its maintainers in the case you need their help with.
++
+. Check if the MobileSecurityService pod is present and running by running `oc get pods`. See in the link:.https://github.com/aerogear/mobile-security-service-operator#Installing[Installing section in the README the expected results]
 . Check if the Mobile Security Service image was pulled successfully.
 . Check the operator pod is present as it is responsible for managing the service pod as described in https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc[MobileSecurityServiceOperatorDown]
 
 === MobileSecurityServiceDatabaseDown
 
-. Check that the Mobile Security Service DB CR is deployed in the same namespace as the operator by running `oc get MobileSecurityServiceDB`
+. Check that the Mobile Security Service DB CR is deployed in the same namespace as the operator by running `oc get MobileSecurityServiceDB`. Following an expected result.
++
+[source,shell]
+----
+$ oc get MobileSecurityServiceDB
+NAME                      AGE
+mobile-security-service-db   7d
+----
++
+NOTE: The MobileSecurityServiceDB need to be applied in order to allow the operator be able to create/manage the Database pod.
++
 . Check the status of the Mobile Security Service CR by running `oc describe MobileSecurityServiceDB`
 +
 NOTE: Check that the status are as expected as described in the https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types[Status Definitions per Types in the README]
 +
-.. Run `oc get pods | grep mobile-security-service-db`
+IMPORTANT: By the CR status you are able to identify what is missing as it is an important information to be send to its maintainers in the case you need their help with.
++
+.. Run `oc get pods | grep mobile-security-service-db`. Following the expected result.
++
+[source,shell]
+----
+$ oc get pods | grep mobile-security-service-db
+mobile-security-service-db-56d7cb55b-8p6cz          1/1       Running   1          7d
+----
 +
 NOTE: By default it should use the values defined in the ConfigMap created by the operator `mobile-security-service-config`. For a further information see link:.https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values[Changing the Environment Variables values in the README]
 +
 . Check the pod logs by running `oc logs <database-podname>`
 +
-NOTE: You can save the logs by running `oc logs <database-podname> > <filename>.log`
+NOTE: You can save the logs by running `oc logs <database-podname> > <filename>.log`. The logs can provided to you useful information in order to identify the root cause of the issue as they are required information to be send to its maintainers in the case it need to be checked by them.
 +
 . Check the operator pod is present as it is responsible for managing the service pod as described in https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc[MobileSecurityServiceOperatorDown]
 
@@ -80,7 +111,9 @@ The following steps would be performed by the Console (OCP UI)
 .. Go to the `Environment` tab
 .. Remove the `Env Var` `LOG_LEVEL` and add a new `Env Var` `LOG_LEVEL` with the value `debug`
 .. After saving the re-deploy of the service will be done automatically then you will be able to get further information
-
++
+NOTE: Improve the level of the logs may bring an useful information for its maintainers are able to do improvements and/or fixed required in order to avoid this scenario.
++
 The following steps which can be performed by CLI:
 
 NOTE: You are able to the the logs by the Console (OCP UI) as well.
@@ -88,8 +121,8 @@ NOTE: You are able to the the logs by the Console (OCP UI) as well.
 . Capture application logs for analysis.
 .. Get the pod names by running `oc get pods`
 .. Save the logs by running `oc logs <database-podname> > <filename>.log` for each pod
-
-NOTE: If necessary, you can recreate the service pod to restore service oc delete pod <service-podname>`.
++
+IMPORTANT: By the CR status you are able to identify what is missing as it is an important information to be send to its maintainers in the case you need their help with. Check that the status are as expected as described in the https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types[Status Definitions per Types in the README]. Also, note that capture the logs can help you to identify the root cause of the issue as provided a required information for its maintainers in order to allow them do fixes and/or improvements with the purpose of avoid this scenario.
 
 == Scaling the pods
 
@@ -97,7 +130,7 @@ You can scale the MSS pod by changing the spec size in the Mobile Security Servi
 
 . Run `oc edit MobileSecurityService` and add the new spec size for it. Also, you can delete and re-apply the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService CR]
 
-NOTE: The architecture of Mobile Security Service do not allow scale its database.
+NOTE: The architecture of Mobile Security Service do not allow scale its database. However, scale the MSS Service pod may will solve the performance issues faced.
 
 
 

--- a/SOP/SOP-mss.adoc
+++ b/SOP/SOP-mss.adoc
@@ -16,143 +16,89 @@ endif::[]
 :toc:
 toc::[]
 
-
 == Critical
 
 === MobileSecurityServiceConsoleDown or MobileSecurityServiceDown
 
-Troubleshoot using the following steps via either the console or the cli:
-
-==== Console:
-
-. Check that the Mobile Security Service CR is deployed in the same namespace as the operator
-. Check the status of the Mobile Security Service CR
-.. Go to `Resources -> Other Resources -> Choose a resource to list -> Mobile Security Service -> Actions -> Edit yaml`
+. Check that the Mobile Security Service CR is deployed in the same namespace as the operator by running `oc get MobileSecurityService`
+. Check the status of the Mobile Security Service CR by running `oc describe MobileSecurityService`
 +
 NOTE: Check that the status are as expected as described in the https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types[Status Definitions per Types in the README]
 +
-. Check the status of the Mobile Security Service DB CR. If the Database Pod is not available this will cause the Service pod to error
-.. Go to `Resources -> Other Resources -> Choose a resource to list -> Mobile Security Service DV -> Actions -> Edit yaml`
-+
-NOTE: Check that the status are as expected as described in the https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types[Status Definitions per Types in the README]
-+
-. Check the environment variables of the Database
-.. Go to : `Applications -> Pods -> mobile-security-service-db-<xyz123> -> Environment Variables`
-.. By default it should use the values defined in the ConfigMap created by the operator `mobile-security-service-config`. For a further information see link:.https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values[Changing the Environment Variables values in the README]
-. Check the logs of the OAuth Proxy Container
-.. Go to : `Applications -> Pods -> mobile-security-service-<xyz123> -> Logs -> Container -> oauth-proxy`
-. Check the logs of the Application Container
-.. Go to : `Applications -> Pods -> mobile-security-service-<xyz123> -> Logs -> Container -> application`
-. Check the `pod/mobile-security-service-<xyz123>` events, see if was possible to pull the MSS image.
-. Check the operator pod is present as it is responsible for managing the service pod as described in https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc[MobileSecurityServiceOperatorDown]
-
-NOTE: If resolving the MobileSecurityServiceOperatorDown doesn't resolve the issue, please continue with the below steps
-
-==== CLI
-
-. Check that the Mobile Security Service CR is deployed in the same namespace as the operator
-. Check the status of the Mobile Security Service CR
-.. Run `oc describe customresourcedefinition.apiextensions.k8s.io/mobilesecurityservices.mobile-security-service.aerogear.com`
-+
-NOTE: Check that the status are as expected as described in the https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types[Status Definitions per Types in the README]
-+
-. Check the status of the Mobile Security Service DB Custom Resource. If the Database Pod is not available this will cause the Service pod to error
-.. Run `oc describe customresourcedefinition.apiextensions.k8s.io/mobilesecurityservicedbs.mobile-security-service.aerogear.com`
-+
-NOTE: Check that the status are as expected as described in the https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types[Status Definitions per Types in the README]
-+
-. Check the environment variables of the Database
-.. Run `oc describe pod/mobile-security-service-db-<xyz123>`
-.. By default it should use the values defined in the ConfigMap created by the operator `mobile-security-service-config`. For a further information see https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values[Changing the Environment Variables values in the README]
-
-. Check the logs of the OAuth Proxy Container
-.. Get the service pod name -> `oc get pods | grep mobile-security-service`
-.. Run `oc logs <service-podname> -c oauth-proxy`
-.. Save the logs by running `oc logs <service-podname> -c oauth-proxy > <filename>.log`
-. Check the logs of the Application Container
-.. Run `oc logs <service-podname> -c application`
-.. Save the logs by running `oc logs <service-podname> -c application > <filename>.log`
-. See the `pod/mobile-security-service-<xyz123>` logs. See if was possible to pull the MSS image.
+. Check if the Mobile Security Service image was pulled successfully.
 . Check the operator pod is present as it is responsible for managing the service pod as described in https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc[MobileSecurityServiceOperatorDown]
 
 === MobileSecurityServiceDatabaseDown
 
-Troubleshoot using the following steps via either the console or the cli:
-
-==== Console
-
-. Check that the Database Pod is deployed in the same namespace as the operator
-. Check the status of the Mobile Security Service DB CR. If the Database Pod is not available this will cause the Service pod to error
-.. Go to: `Resources -> Other Resources -> Choose a resource to list -> Mobile Security Service DB-> Actions -> Edit yaml`
+. Check that the Mobile Security Service DB CR is deployed in the same namespace as the operator by running `oc get MobileSecurityServiceDB`
+. Check the status of the Mobile Security Service CR by running `oc describe MobileSecurityServiceDB`
 +
 NOTE: Check that the status are as expected as described in the https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types[Status Definitions per Types in the README]
 +
-. Check the environment variables of the Database
-.. Go to : `Applications -> Pods -> mobile-security-service-db-<xyz123> -> Environment Variables`
-.. By default it should use the values defined in the ConfigMap created by the operator `mobile-security-service-config`. For a further information see link:.https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values[Changing the Environment Variables values in the README]
-. Check the pod logs
-.. Navigate to `Applications -> Pods -> mobile-security-service-db-<xyz123> -> Logs
-. Check the `pod/mobile-security-service-db-<xyz123>` events, see if was possible to pull the Database image.
-. Check the operator pod is present as it is responsible for managing the service pod as described in https://github.com/aerogear/mobile-security-service-operator/SOP/SOP-operator.md[MobileSecurityServiceOperatorDown]
-
-==== CLI`
-
-. Check that the Database Pod is deployed in the same namespace as the operator
-. Check the status of the Mobile Security Service DB CR. If the Database Pod is not available this will cause the Service pod to error
-.. Run `oc describe customresourcedefinition.apiextensions.k8s.io/mobilesecurityservicedbs.mobile-security-service.aerogear.com`
+.. Run `oc get pods | grep mobile-security-service-db`
 +
-NOTE: Check that the status are as expected as described in the https://github.com/aerogear/mobile-security-service-operator#status-definition-per-types[Status Definitions per Types in the README]
+NOTE: By default it should use the values defined in the ConfigMap created by the operator `mobile-security-service-config`. For a further information see link:.https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values[Changing the Environment Variables values in the README]
 +
-.. Run `oc describe pod/mobile-security-service-db-<xyz123>`
-.. By default it should use the values defined in the ConfigMap created by the operator `mobile-security-service-config`. For a further information see link:.https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values[Changing the Environment Variables values in the README]
-. Check the pod logs
-.. Get the service pod name -> `oc get pods | grep mobile-security-service-db`
-.. `oc logs <database-podname>`
-.. Save the logs by running `oc logs <database-podname> > <filename>.log`
-. Check the `pod/mobile-security-service-db-<xyz123>` logs, see if was possible to pull the Database image.
+. Check the pod logs by running `oc logs <database-podname>`
++
+NOTE: You can save the logs by running `oc logs <database-podname> > <filename>.log`
++
 . Check the operator pod is present as it is responsible for managing the service pod as described in https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc[MobileSecurityServiceOperatorDown]
 
 == Warning
 
-=== MobileSecurityServicePodCPUHigh or MobileSecurityServicePodMemoryHigh
+=== MobileSecurityServicePodCPUHigh
+
+. Please following the <<General procedure>> procedure before in order to capture the logs and send it to its maintainers.
+. In order to solve following the steps to <<Scaling the pods>>.
+
+=== MobileSecurityServicePodMemoryHigh
+
+. Please following the <<General procedure>> procedure before in order to capture the logs and send it to its maintainers.
+. In order to solve following the steps to <<Scaling the pods>>.
+
+=== MobileSecurityServiceApiHighRequestDuration
+
+. Please following the <<General procedure>> procedure before in order to capture the logs and send it to its maintainers.
+. In order to solve following the steps to <<Scaling the pods>>.
+
+=== MobileSecurityServiceApiHighRequestFailure
+
+. Please following the <<General procedure>> procedure before in order to capture the logs and send it to its maintainers.
+
+=== MobileSecurityServiceApiHighConcurrentRequests
+
+. Please following the <<General procedure>> procedure before in order to capture the logs and send it to its maintainers.
+
+== General procedure
+
+The following steps would be performed by the Console (OCP UI)
 
 . Capture a snapshot of the 'Mobile Security Service Application' Grafana dashboard and track it over time. The metrics can be useful for identifying performance issues over time.
 . Increase the log level of the Service pod (`pod/mobile-security-service-<xyz123>`)
-.. Go to `Applications -> Deployment`
-.. Click on in the `mobile-security-service`
+.. Go to `Applications -> Deployment` and click on in the `mobile-security-service`
 .. Go to the `Environment` tab
-.. Remove the `Env Var` `LOG_LEVEL`
-.. Add a new `Env Var` `LOG_LEVEL` with the value `debug`
+.. Remove the `Env Var` `LOG_LEVEL` and add a new `Env Var` `LOG_LEVEL` with the value `debug`
 .. After saving the re-deploy of the service will be done automatically then you will be able to get further information
 
-=== MobileSecurityServiceApiHighRequestDuration, MobileSecurityServiceApiHighRequestFailure , MobileSecurityServiceApiHighConcurrentRequests
+The following steps which can be performed by CLI:
 
-Troubleshoot using the following steps via either the console and/or the cli:
-
-. Capture a snapshot of the 'Mobile Security Service Application' Grafana dashboard and track it over time. The metrics can be useful for identifying performance issues over time.
-
-==== Console:
+NOTE: You are able to the the logs by the Console (OCP UI) as well.
 
 . Capture application logs for analysis.
-.. Go to : `Applications -> Pods -> mobile-security-service-<xyz123> -> Logs -> Container -> application`
-.. Go to : `Applications -> Pods -> mobile-security-service-<xyz123> -> Logs -> Container -> oauth-proxy`
-. Increase the log level of the Service pod (`pod/mobile-security-service-<xyz123>`)
-.. Go to `Applications -> Deployment`
-.. Click on in the `mobile-security-service`
-.. Go to the `Environment` tab
-.. Remove the `Env Var` `LOG_LEVEL`
-.. Add new `Env Var` `LOG_LEVEL` with the value `debug`
-.. After saving the re-deploy of the service will be done automatically then you will be able to get further information
-. If necessary, recreate the service pod to restore service.
-.. Navigate to `Application -> Pods -> mobile-security-service-<xyz123> -> Actions -> Delete -> Delete`
+.. Get the pod names by running `oc get pods`
+.. Save the logs by running `oc logs <database-podname> > <filename>.log` for each pod
 
-==== CLI:
+NOTE: If necessary, you can recreate the service pod to restore service oc delete pod <service-podname>`.
 
-. Capture application logs for analysis.
-.. Get the service pod name -> `oc get pods | grep mobile-security-service`
-.. `oc logs <service-podname> -c application`
-.. Save the logs by running `oc logs <service-podname> -c application > <filename>.log`
-. Increase the log level of the Service pod (`pod/mobile-security-service-<xyz123>`) 
-. If necessary, recreate the service pod to restore service.
-. Get the service pod name -> `oc get pods | grep mobile-security-service`
-. oc delete pod <service-podname>
+== Scaling the pods
+
+You can scale the MSS pod by changing the spec size in the Mobile Security Service CR. See link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService CR].
+
+. Run `oc edit MobileSecurityService` and add the new spec size for it. Also, you can delete and re-apply the link:./deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml[MobileSecurityService CR]
+
+NOTE: The architecture of Mobile Security Service do not allow scale its database.
+
+
+
+

--- a/SOP/SOP-operator.adoc
+++ b/SOP/SOP-operator.adoc
@@ -18,56 +18,16 @@ toc::[]
 
 == MobileSecurityServiceOperatorDown
 
-Troubleshoot using the following steps via either the console or the cli:
-
-=== Console:
-
-. Log into the OpenShift console
-. Switch to the Mobile Security Service namespace
-. Go to `Deployments -> mobile-security-service-operator >> Events` and check if was possible pull the image
-. Check the logs of the pod for any errors
-.. Navigate to `Applications -> Pods -> mobile-security-service-operator-<xyz123> -> Logs`
-.. Check for any errors in the logs
-. Try to scale up the pod if it is not present
-.. Navigate to `Overview -> Click Dropdown for Deployment mobile-security-service-operator -> Click on up arrow to scale the pod to 1`
-
-=== CLI:
-
-. Login
-.. Run `oc login <openshift-url>:8443 -u <username> -p <password>`
-. Switch to the Mobile Security Service namespace
-.. Run `oc project mobile-security-service`
-. If the operator pod is present check the logs of the pod for any errors
-. Get the operator pod name -> `oc get pods | grep operator`
-. `oc logs <operator-podname>`
-. Save the logs by running `oc logs <operator-podname> > <filename>.log`
-. If the operator pod is not preset scale up the pod
-.. `oc scale deployments mobile-security-service-operator --replicas=1`
-
+. Switch to the Mobile Security Service namespace by running `oc project mobile-security-service`
+. Check if the operator pod to is present by running `oc get pods | grep operator`
+. Check its logs by running `oc logs <operator-podname>`
++
+NOTE: You can save the logs by running `oc logs <operator-podname> > <filename>.log`
+. If the operator pod is not preset check its installation. May will be required re-install the project or just the link:./deploy/operator.yaml[operator.yaml] file.
 
 == MobileSecurityServicePodCount
 
-Troubleshoot using the following steps via either the console or the cli:
+. Switch to the Mobile Security Service namespace by running `oc project mobile-security-service`
+. Check if it has at least 3 pods (Service, Database and Operator) by running `oc get pods`. See in the https://github.com/aerogear/mobile-security-service-operator#Installing[Installing section on the README] the expected results.
 
-=== Console:
-. Log into the OpenShift cluster
-. Switch to the Mobile Security Service namespace
-. Navigate to the Overview using the side navigation
-. Check the following
-.. There is one pod running under the application mobilesecurityservice
-.. There is one pod running under the application mobilesecurityservicedb
-.. There is one pod running under the Other Resources
-
-=== CLI:
-
-. Login
-.. Run `oc login <openshift-url>:8443 -u <username> -p <password>`
-. Switch to the Mobile Security Service namespace
-.. Run `oc project mobile-security-service`
-. Check the following
-. Run `oc get pods`
-.. There is one pod running under READY for pod mobile-security-service-<xyz123>
-.. There is one pod running under READY for pod mobile-security-service-db-<xyz123>
-.. There is one pod running under READY for pod mobile-security-service-operator<xyz123>
-. The operator should  maintain the number of pods running for the mobilesecurity service, please resolve the operator pod numbers first by scaling it up or down as necessary.
-.. `oc scale deployments mobile-security-service-operator --replicas=1`
+NOTE: The operator should  maintain the number of pods running for the Mobile Security Service and its Database.

--- a/SOP/SOP-operator.adoc
+++ b/SOP/SOP-operator.adoc
@@ -18,16 +18,23 @@ toc::[]
 
 == MobileSecurityServiceOperatorDown
 
-. Switch to the Mobile Security Service namespace by running `oc project mobile-security-service`
-. Check if the operator pod to is present by running `oc get pods | grep operator`
+. Switch to the Mobile Security Service namespace by running `oc project <namespace>`. E.g `oc project mobile-security-service`
+. Check if the operator pod to is present by running `oc get pods | grep operator`. Following an example of the expected result.
++
+[source,shell]
+----
+$ oc get pods | grep operator
+mobile-security-service-operator-785cbdbf46-wrhzq   1/1       Running   3          7d
+----
 . Check its logs by running `oc logs <operator-podname>`
 +
-NOTE: You can save the logs by running `oc logs <operator-podname> > <filename>.log`
+NOTE: You can save the logs by running `oc logs <operator-podname> > <filename>.log`. The logs may provide to you the required information in order to allow you identify the root cause of this issue as it is a required information for its maintainers are able to help you with.
+. Check if the Mobile Security Service operator image was pulled successfully. Its images are published in https://quay.io/repository/aerogear/mobile-security-service-operator[https://quay.io/repository/aerogear/mobile-security-service-operator].
 . If the operator pod is not preset check its installation. May will be required re-install the project or just the link:./deploy/operator.yaml[operator.yaml] file.
 
 == MobileSecurityServicePodCount
 
-. Switch to the Mobile Security Service namespace by running `oc project mobile-security-service`
+. Switch to the Mobile Security Service namespace by running `oc project <namespace>`. E.g `oc project mobile-security-service`
 . Check if it has at least 3 pods (Service, Database and Operator) by running `oc get pods`. See in the https://github.com/aerogear/mobile-security-service-operator#Installing[Installing section on the README] the expected results.
 
 NOTE: The operator should  maintain the number of pods running for the Mobile Security Service and its Database.

--- a/deploy/monitor/mss_prometheus_rule.yaml
+++ b/deploy/monitor/mss_prometheus_rule.yaml
@@ -15,7 +15,7 @@ spec:
     - name: general.rules
       rules:
       - alert: MobileSecurityServiceDown
-        expr: absent(up{job="mobile-security-service-application"} == 1)
+        expr: absent(kube_pod_container_status_running{namespace="mobile-security-service",container="application"}==1)
         for: 5m
         labels:
           severity: critical

--- a/deploy/monitor/mss_prometheus_rule.yaml
+++ b/deploy/monitor/mss_prometheus_rule.yaml
@@ -15,7 +15,7 @@ spec:
     - name: general.rules
       rules:
       - alert: MobileSecurityServiceDown
-        expr: absent(kube_pod_container_status_running{namespace="mobile-security-service",container="application"}==1)
+        expr: absent(kube_pod_container_status_running{namespace="mobile-security-service",container="application"}>=1)
         for: 5m
         labels:
           severity: critical
@@ -24,7 +24,7 @@ spec:
           summary: "The mobile-security-service is down. For more information see on the MSS at https://github.com/aerogear/mobile-security-service"
           sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-mss.adoc"
       - alert: MobileSecurityServiceConsoleDown
-        expr: absent(kube_endpoint_address_available{endpoint="mobile-security-service-application"} == 1)
+        expr: absent(kube_endpoint_address_available{endpoint="mobile-security-service-application"} >= 1)
         for: 5m
         labels:
           severity: critical

--- a/deploy/monitor/prometheus_rule.yaml
+++ b/deploy/monitor/prometheus_rule.yaml
@@ -25,8 +25,8 @@ spec:
           sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc"
       - alert: MobileSecurityServicePodCount
         annotations:
-          description: The Pod count for the mobile-security-service has changed in the last 5 minutes and has not the minimal quantity required.
-          summary: Pod count for namespace mobile-security-service is {{ printf "%.0f" $value }}. Expected 3 pods. For more information see on the MSS operator https://github.com/aerogear/mobile-security-service-operator"
+          description: "The Pod count for the mobile-security-service has changed in the last 5 minutes and is less than the minimal required value."
+          summary: "Pod count for namespace mobile-security-service is {{ printf '%.0f' $value }}. Expected 3 pods. For more information see on the MSS operator https://github.com/aerogear/mobile-security-service-operator"
           sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc"
         expr: |
           (1-absent(kube_pod_status_ready{condition="true", namespace="mobile-security-service"})) or sum(kube_pod_status_ready{condition="true", namespace="mobile-security-service"}) < 3

--- a/deploy/monitor/prometheus_rule.yaml
+++ b/deploy/monitor/prometheus_rule.yaml
@@ -23,13 +23,13 @@ spec:
           description: "The mobile-security-service-operator has been down for more than 5 minutes. "
           summary: "The mobile-security-service-operator is down. For more information see on the MSS operator https://github.com/aerogear/mobile-security-service-operator"
           sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc"
-      - alert: MobileSecurityServicePodcount
+      - alert: MobileSecurityServicePodCount
         annotations:
-          description: The Pod count for the mobile-security-service has changed in the last 5 minutes.
+          description: The Pod count for the mobile-security-service has changed in the last 5 minutes and has not the minimal quantity required.
           summary: Pod count for namespace mobile-security-service is {{ printf "%.0f" $value }}. Expected 3 pods. For more information see on the MSS operator https://github.com/aerogear/mobile-security-service-operator"
           sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc"
         expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="mobile-security-service"})) or sum(kube_pod_status_ready{condition="true", namespace="mobile-security-service"}) != 3
+          (1-absent(kube_pod_status_ready{condition="true", namespace="mobile-security-service"})) or sum(kube_pod_status_ready{condition="true", namespace="mobile-security-service"}) < 3
         for: 5m
         labels:
           severity: warning


### PR DESCRIPTION
## Motivation
- https://issues.jboss.org/browse/INTLY-2709 ( raised after discussions over UPS SOP and Prometheus rules and the review over it)

## What
- Remove the CLI steps from the SOP's
- Small fixes in the steps
- Fix the MobileSecurityServicePodCount ( it should alert when the pods are < 3 and NOT != of 3 )
- Fix the MobileSecurityServiceDown ( it was not working at all and shown the alert when the MSS pod was up and running )
- Add steps to scale the MSS pods in the case of some issues regards performance be faced.
- Add further information in order to attend the OPS suggestions/requirements

## Verification Steps
- Check the Sops [MMS](https://github.com/aerogear/mobile-security-service-operator/blob/3729f93bb71b836efd8ed6a25d1869231ef5339f/SOP/SOP-mss.adoc) and [Oper](https://github.com/aerogear/mobile-security-service-operator/blob/3729f93bb71b836efd8ed6a25d1869231ef5339f/SOP/SOP-operator.adoc)

- Check here the Prometheus Rule changed: https://prometheus-route-middleware-monitoring.apps.london-4bc4.openshiftworkshop.com/alerts

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes
<img width="561" alt="Screenshot 2019-07-12 at 08 12 13" src="https://user-images.githubusercontent.com/7708031/61124284-df412800-a47c-11e9-9248-7f7dea19cc0d.png">

