### PR TITLE
fix(Prometheus Rules) : Remove MobileSecurityServicePodCount since it…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Remove MobileSecurityServicePodCount since it was considered duplicated [#157](https://github.com/aerogear/mobile-security-service-operator/pull/157)
 
 ## [0.3.0] - 2019-07-26
 - Fixed Prometheus Rules for MobileSecurityServicePodCount and MobileSecurityServiceDown [#151](https://github.com/aerogear/mobile-security-service-operator/pull/151)

--- a/SOP/SOP-operator.adoc
+++ b/SOP/SOP-operator.adoc
@@ -49,15 +49,6 @@ IMPORTANT: If the operator pod is not preset check its installation. See https:/
 +
 TIP: May will be required re-install the project or just the link:./deploy/operator.yaml[operator.yaml] file if all kinds of CR and CRD's are applied in the namespace. See the https://github.com/aerogear/mobile-security-service-operator#crd-definitions[CRD Definitions] to know all kinds.
 
-=== Warning
-
-==== MobileSecurityServicePodCount
-
-. Switch to the Mobile Security Service namespace by running `oc project <namespace>`. E.g `oc project mobile-security-service`
-. Check if it has at least 3 pods (Service, Database and Operator) by running `oc get pods`. See https://github.com/aerogear/mobile-security-service-operator#Installing[Installing] README section to check the expected results.
-
-NOTE: The operator should  maintain the number of pods running for the MSS Service and its Database.
-
 == Validate
 
 . Check if the operator pod to is present by running `oc get pods | grep operator`. Following an example of the expected result.

--- a/deploy/monitor/prometheus_rule.yaml
+++ b/deploy/monitor/prometheus_rule.yaml
@@ -23,13 +23,3 @@ spec:
           description: "The mobile-security-service-operator has been down for more than 5 minutes. "
           summary: "The mobile-security-service-operator is down. For more information see on the MSS operator https://github.com/aerogear/mobile-security-service-operator"
           sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc"
-      - alert: MobileSecurityServicePodCount
-        annotations:
-          description: "The Pod count for the mobile-security-service has changed in the last 5 minutes and is less than the minimal required value."
-          summary: Pod count for namespace mobile-security-service is {{ printf "%.0f" $value }}. Expected 3 pods. For more information see on the MSS operator https://github.com/aerogear/mobile-security-service-operator
-          sop_url: "https://github.com/aerogear/mobile-security-service-operator/blob/0.2.0/SOP/SOP-operator.adoc"
-        expr: |
-          (1-absent(kube_pod_status_ready{condition="true", namespace="mobile-security-service"})) or sum(kube_pod_status_ready{condition="true", namespace="mobile-security-service"}) < 3
-        for: 5m
-        labels:
-          severity: warning


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9642

## What
- Remove MobileSecurityServicePodCount since it was considered redundant

## Why
According to the convention/standard, we have already the specific rule for each pod. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO
