### PR TITLE
fix(operator metrics): path export metrics (AEROGEAR-9664)

### DIFF
--- a/deploy/monitor/mss_service_monitor.yaml
+++ b/deploy/monitor/mss_service_monitor.yaml
@@ -7,7 +7,7 @@ metadata:
   name: mobile-security-service
 spec:
   endpoints:
-    - path: /api/metrics
+    - path: /rest/prometheus/metrics
       port: server
   selector:
     matchLabels:


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9664

## What
Fix MSS Monitor Service prometheus api path 

## Why
It was wrong

## Verification Steps
Apply this change in the Service Monitor in the testing cluster or check it changed here: https://prometheus-route-middleware-monitoring.apps.london-79f0.openshiftworkshop.com/alerts
<img width="1070" alt="Screenshot 2019-08-05 at 22 21 30" src="https://user-images.githubusercontent.com/7708031/62495955-65783200-b7cf-11e9-9efa-087e564911b7.png">

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

 
