### PR TITLE
Fix the chart `Mobile Security Service Application - Uptime` on Grafana application dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 - Remove MobileSecurityServicePodCount since it was considered duplicated [#157](https://github.com/aerogear/mobile-security-service-operator/pull/157)
+- Fix the chart `Mobile Security Service Application - Uptime` on Grafana application dashboard [#164](https://github.com/aerogear/mobile-security-service-operator/pull/164)
 
 ## [0.3.0] - 2019-07-26
 - Fixed Prometheus Rules for MobileSecurityServicePodCount and MobileSecurityServiceDown [#151](https://github.com/aerogear/mobile-security-service-operator/pull/151)

--- a/deploy/monitor/mss_grafana_dashboard.yaml
+++ b/deploy/monitor/mss_grafana_dashboard.yaml
@@ -484,7 +484,7 @@ spec:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg(up{job=\"mobile-security-service-application\"})*100",
+              "expr": "avg(kube_pod_container_status_running{namespace='mobile-security-service',container='application'})*100",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -541,10 +541,10 @@ spec:
           "steppedLine": true,
           "targets": [
             {
-              "expr": "up{job='mobile-security-service-application'}",
+              "expr": "kube_pod_container_status_running{namespace='mobile-security-service',container='application'}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "Mobile Security Service Applition - Uptime",
+              "legendFormat": "Mobile Security Service Application - Uptime",
               "refId": "A"
             }
           ],


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9714

## What
Fix the following issue:

<img width="750" alt="Screenshot 2019-08-06 at 15 02 44" src="https://user-images.githubusercontent.com/7708031/62547311-efbaa780-b85c-11e9-942a-62b2416f3841.png">
<img width="1613" alt="Screenshot 2019-08-06 at 15 02 24" src="https://user-images.githubusercontent.com/7708031/62547312-efbaa780-b85c-11e9-9dc5-5475cea0db34.png">

## Why
It is not getting the info over the app container. 
See the metric which should be used
<img width="1535" alt="Screenshot 2019-08-06 at 15 15 57" src="https://user-images.githubusercontent.com/7708031/62547466-27295400-b85d-11e9-98b1-7d236f76fdd1.png">


## How
Update the metrics o fix them

## Verification Steps
Use this JSON file in aa Grafana dashboard in an env which has all work as https://master.mdsdemo-710a.openshiftworkshop.com/console/project/middleware-monitoring/overview

## Checklist:

- [X] Code has been tested locally by PR requester

Test performed here: https://grafana-route-middleware-monitoring.apps.mdsdemo-710a.openshiftworkshop.com/d/H6GQ0MvWz/mobile-security-service-application

<img width="1606" alt="Screenshot 2019-08-06 at 15 21 36" src="https://user-images.githubusercontent.com/7708031/62547928-f4339000-b85d-11e9-8232-c346e80d75ad.png">


- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished task
- [ ] TODO

## Additional Notes

PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. 
 
