### PR TITLE
feat(resources) : Add resource requests/limits to MSS & MSS operator AEROGEAR-9767)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Change/Add Memory and CPU resources requested and limits for MSS, Oauth and Operator [#172](https://github.com/aerogear/mobile-security-service-operator/pull/172)
 
 ## [0.4.0] - 2019-08-13
 - Remove MobileSecurityServicePodCount since it was considered duplicated [#157](https://github.com/aerogear/mobile-security-service-operator/pull/157)

--- a/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
+++ b/deploy/crds/mobile-security-service_v1alpha1_mobilesecurityservice_cr.yaml
@@ -39,8 +39,10 @@ spec:
 
   image: "quay.io/aerogear/mobile-security-service:0.2.2"
   containerName: "application"
-  memoryLimit: "512Mi"
-  memoryRequest: "512Mi"
+  memoryLimit: "128Mi"
+  memoryRequest: "64Mi"
+  resourceCpuLimit: "20m"
+  resourceCpu: "10m"
   # Use the following spec if you would like to define the image pull policy
   # containerImagePullPolicy: "IfNotPresent"
 
@@ -50,6 +52,13 @@ spec:
 
   oAuthImage: "docker.io/openshift/oauth-proxy:v1.1.0"
   oAuthContainerName: "oauth-proxy"
+  oAuthMemoryLimit: "64Mi"
+  oAuthMemoryRequest: "32Mi"
+  oAuthResourceCpuLimit: "20m"
+  oAuthResourceCpu: "10m"
+
   # Use the following spec if you would like to define the image policy
   # oAuthContainerImagePullPolicy: "IfNotPresent"
+
+
 

--- a/deploy/crds/mobilesecurityservice_v1alpha1_mobilesecurityservice_crd.yaml
+++ b/deploy/crds/mobilesecurityservice_v1alpha1_mobilesecurityservice_crd.yaml
@@ -101,11 +101,30 @@ spec:
               description: 'Oauth image:tag E.g docker.io/openshift/oauth-proxy:v1.1.0
                 More info: https://github.com/openshift/oauth-proxy'
               type: string
+            oAuthMemoryLimit:
+              description: Limit of Memory which will be available for the OAuth container
+              type: string
+            oAuthMemoryRequest:
+              description: Limit of Memory Request which will be available for the
+                OAuth container
+              type: string
+            oAuthResourceCpu:
+              description: CPU resource which will be available for the OAuth container
+              type: string
+            oAuthResourceCpuLimit:
+              description: Limit of CPU which will be available for the OAuth container
+              type: string
             port:
               description: 'Value for the Service Environment Variable (PORT) More
                 info: https://github.com/aerogear/mobile-security-service-operator#changing-the-environment-variables-values'
               format: int32
               type: integer
+            resourceCpu:
+              description: CPU resource which will be available for the Service container
+              type: string
+            resourceCpuLimit:
+              description: Limit of CPU which will be available for the Service container
+              type: string
             routeName:
               description: The name of the route which will vbe created to expose
                 the Service

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,6 +20,13 @@ spec:
           command:
           - mobile-security-service-operator
           imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 60m
+              memory: 128Mi
+            requests:
+              cpu: 30m
+              memory: 64Mi
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservice_types.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/mobilesecurityservice_types.go
@@ -61,6 +61,18 @@ type MobileSecurityServiceSpec struct {
 	MemoryLimit string `json:"memoryLimit,omitempty"`
 	// Limit of Memory Request which will be available for the Service container
 	MemoryRequest string `json:"memoryRequest,omitempty"`
+	// Limit of CPU which will be available for the Service container
+	ResourceCpuLimit string `json:"resourceCpuLimit,omitempty"`
+	// CPU resource which will be available for the Service container
+	ResourceCpu string `json:"resourceCpu,omitempty"`
+	// Limit of Memory which will be available for the OAuth container
+	OAuthMemoryLimit string `json:"oAuthMemoryLimit,omitempty"`
+	// Limit of Memory Request which will be available for the OAuth container
+	OAuthMemoryRequest string `json:"oAuthMemoryRequest,omitempty"`
+	// Limit of CPU which will be available for the OAuth container
+	OAuthResourceCpuLimit string `json:"oAuthResourceCpuLimit,omitempty"`
+	// CPU resource which will be available for the OAuth container
+	OAuthResourceCpu string `json:"oAuthResourceCpu,omitempty"`
 	// Oauth image:tag E.g docker.io/openshift/oauth-proxy:v1.1.0
 	// More info: https://github.com/openshift/oauth-proxy
 	OAuthImage string `json:"oAuthImage,omitempty"`

--- a/pkg/apis/mobilesecurityservice/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/mobilesecurityservice/v1alpha1/zz_generated.openapi.go
@@ -735,7 +735,7 @@ func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceSpec(re
 					},
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Service image:tag E.g quay.io/aerogear/mobile-security-service:0.2.2",
+							Description: "Service image:tag E.g quay.io/aerogear/mobile-security-service:0.1.0",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -764,6 +764,48 @@ func schema_pkg_apis_mobilesecurityservice_v1alpha1_MobileSecurityServiceSpec(re
 					"memoryRequest": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Limit of Memory Request which will be available for the Service container",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"resourceCpuLimit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Limit of CPU which will be available for the Service container",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"resourceCpu": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CPU resource which will be available for the Service container",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"oAuthMemoryLimit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Limit of Memory which will be available for the OAuth container",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"oAuthMemoryRequest": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Limit of Memory Request which will be available for the OAuth container",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"oAuthResourceCpuLimit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Limit of CPU which will be available for the OAuth container",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"oAuthResourceCpu": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CPU resource which will be available for the OAuth container",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/controller/mobilesecurityservice/controller_test.go
+++ b/pkg/controller/mobilesecurityservice/controller_test.go
@@ -65,6 +65,9 @@ func TestReconcileMobileSecurityService_update(t *testing.T) {
 				},
 			}
 
+			// Add const values for mandatory specs
+			addMandatorySpecsDefinitions(tt.fields.instanceToUpdate)
+
 			res, err := r.Reconcile(req)
 			if err != nil {
 				t.Fatalf("reconcile: (%v)", err)

--- a/pkg/controller/mobilesecurityservice/deployments.go
+++ b/pkg/controller/mobilesecurityservice/deployments.go
@@ -66,6 +66,16 @@ func buildOAuthContainer(mss *mobilesecurityservicev1alpha1.MobileSecurityServic
 		Args:                     getOAuthArgsMap(mss),
 		TerminationMessagePath:   "/dev/termination-log",
 		TerminationMessagePolicy: "File",
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse(mss.Spec.OAuthMemoryLimit),
+				corev1.ResourceCPU:    resource.MustParse(mss.Spec.OAuthResourceCpuLimit),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse(mss.Spec.OAuthMemoryRequest),
+				corev1.ResourceCPU:    resource.MustParse(mss.Spec.OAuthResourceCpu),
+			},
+		},
 	}
 }
 
@@ -119,9 +129,11 @@ func buildApplicationContainer(mss *mobilesecurityservicev1alpha1.MobileSecurity
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse(mss.Spec.MemoryLimit),
+				corev1.ResourceCPU:    resource.MustParse(mss.Spec.ResourceCpuLimit),
 			},
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse(mss.Spec.MemoryRequest),
+				corev1.ResourceCPU:    resource.MustParse(mss.Spec.ResourceCpu),
 			},
 		},
 	}

--- a/pkg/controller/mobilesecurityservice/mandatory_specs.go
+++ b/pkg/controller/mobilesecurityservice/mandatory_specs.go
@@ -17,7 +17,13 @@ const (
 	size                          = 1
 	clusterProtocol               = "http"
 	memoryLimit                   = "512Mi"
-	memoryRequest                 = "512Mi"
+	memoryRequest                 = "128Mi"
+	resourceCpuLimit              = "20m"
+	resourceCpu                   = "10m"
+	oAuthMemoryLimit              = "64Mi"
+	oAuthMemoryRequest            = "32Mi"
+	oAuthResourceCpuLimit         = "20m"
+	oAuthResourceCpu              = "10m"
 	image                         = "quay.io/aerogear/mobile-security-service:0.2.2"
 	containerName                 = "application"
 	oAuthImage                    = "docker.io/openshift/oauth-proxy:v1.1.0"
@@ -94,6 +100,30 @@ func addMandatorySpecsDefinitions(mss *mobilesecurityservicev1alpha1.MobileSecur
 
 	if mss.Spec.MemoryRequest == "" {
 		mss.Spec.MemoryRequest = memoryRequest
+	}
+
+	if mss.Spec.ResourceCpu == "" {
+		mss.Spec.ResourceCpu = resourceCpu
+	}
+
+	if mss.Spec.ResourceCpuLimit == "" {
+		mss.Spec.ResourceCpuLimit = resourceCpuLimit
+	}
+
+	if mss.Spec.OAuthMemoryLimit == "" {
+		mss.Spec.OAuthMemoryLimit = oAuthMemoryLimit
+	}
+
+	if mss.Spec.OAuthMemoryRequest == "" {
+		mss.Spec.OAuthMemoryRequest = oAuthMemoryRequest
+	}
+
+	if mss.Spec.OAuthResourceCpu == "" {
+		mss.Spec.OAuthResourceCpu = oAuthResourceCpu
+	}
+
+	if mss.Spec.OAuthResourceCpuLimit == "" {
+		mss.Spec.OAuthResourceCpuLimit = oAuthResourceCpuLimit
 	}
 
 	if mss.Spec.RouteName == "" {


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-9767

## What
- Change/Add Memory and CPU resources requested and limits for MSS, Oauth and Operator

## Steps to Verify
- Check the CI
- Use the image `cmacedo/mobile-security-service-operator:new` to install the MSS and check if the values defined in AEROGEAR-9767 are set up in its containers. 

## Progress

- [x] Finished task
- [ ] TODO

## Local Tests:

### Verification of oper
<img width="452" alt="Screenshot 2019-08-22 at 12 33 05" src="https://user-images.githubusercontent.com/7708031/63511402-0c9bdf80-c4d9-11e9-9807-a5db2f5736b6.png">

### verification of oauth and service

<img width="687" alt="Screenshot 2019-08-22 at 12 32 55" src="https://user-images.githubusercontent.com/7708031/63511408-0f96d000-c4d9-11e9-9d69-961550c126a3.png">